### PR TITLE
[server] CRUD events to replace activities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -851,6 +851,21 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fullcalendar/core": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-4.4.0.tgz",
+      "integrity": "sha512-PC4mmXHJHAlXmUEmZVnePyA8yYCOBdxBNq8yjJqedEtT1X0x36yTFz/Y0Ux6bniICZDqYtk0xoxe6jaxi++e0g=="
+    },
+    "@fullcalendar/daygrid": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-4.4.0.tgz",
+      "integrity": "sha512-pDfvL0XZxKHTZ4VFOmwaYe3LmuABEIZsEopeqQ8y5O6BDen9KCbJqgHeCI8FpASSBd6bNlUx7il7EHdSoHhgIw=="
+    },
+    "@fullcalendar/interaction": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-4.4.0.tgz",
+      "integrity": "sha512-nGu0ZzYYlNpIhqfyv3JupteWKFETs3W1MzbRJcEZkuPncn4BooEi4A2blgHfacHAmmpaNkT84tAmhzi734MFBA=="
+    },
     "@polka/url": {
       "version": "1.0.0-next.11",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,9 @@
     "test": "run-p --race dev cy:run"
   },
   "dependencies": {
+    "@fullcalendar/core": "^4.4.0",
+    "@fullcalendar/daygrid": "^4.4.0",
+    "@fullcalendar/interaction": "^4.4.0",
     "axios": "^0.19.0",
     "compression": "^1.7.1",
     "date-fns": "^2.9.0",

--- a/client/src/routes/_components/Nav.svelte
+++ b/client/src/routes/_components/Nav.svelte
@@ -31,6 +31,9 @@
   {#if process.browser && $user}
     <div class="collapse navbar-collapse" id="nav">
       <ul class="navbar-nav mr-auto">
+        <li class="nav-item {segment === 'faircalendar' ? 'active' : ''}">
+          <a class="nav-link" href="faircalendar">FairCalendar</a>
+        </li>
         <li class="nav-item {segment === 'activities' ? 'active' : ''}">
           <a class="nav-link" href="activities">CRA</a>
         </li>

--- a/client/src/routes/faircalendar/[date].add.svelte
+++ b/client/src/routes/faircalendar/[date].add.svelte
@@ -1,0 +1,50 @@
+<script context="module">
+  export const preload = ({params}) => {
+    return {date: params.date};
+  };
+</script>
+
+<script>
+  import {goto} from '@sapper/app';
+  import {format} from 'date-fns';
+  import {fr} from 'date-fns/locale';
+  import Breadcrumb from '../_components/Breadcrumb.svelte';
+  import {client as axios} from '../../utils/axios';
+  import Form from './_Form.svelte';
+  import {errorNormalizer} from '../../normalizer/errors';
+  import ServerErrors from '../_components/ServerErrors.svelte';
+
+  export let date;
+
+  let pageTitle = `Ajout d'activité du ${format(
+    new Date(date),
+    'EEEE dd MMMM yyyy',
+    {
+      locale: fr
+    }
+  )}`;
+  let errors = [];
+
+  const onSave = async e => {
+    try {
+      await axios.post('events', e.detail);
+
+      return goto('/faircalendar');
+    } catch (e) {
+      errors = errorNormalizer(e);
+    }
+  };
+</script>
+
+<svelte:head>
+  <title>Permacoop - {pageTitle}</title>
+</svelte:head>
+
+<div class="col-md-12">
+  <Breadcrumb
+    items={[{title: 'FairCalendar', path: 'faircalendar'}, {title: pageTitle}]} />
+  <ServerErrors {errors} />
+  <Form
+    on:save={onSave}
+    event={{date, type: 'mission', time: '100', summary: '', taskId: null, projectId: null}} />
+</div>

--- a/client/src/routes/faircalendar/[id].edit.svelte
+++ b/client/src/routes/faircalendar/[id].edit.svelte
@@ -1,0 +1,62 @@
+<script context="module">
+  import {client as axios} from '../../utils/axios';
+
+  export const preload = async ({params}) => {
+    const {data} = await axios.get(`events/${params.id}`);
+
+    return {event: data};
+  };
+</script>
+
+<script>
+  import Breadcrumb from '../_components/Breadcrumb.svelte';
+  import {format} from 'date-fns';
+  import {fr} from 'date-fns/locale';
+  import {goto} from '@sapper/app';
+  import Form from './_Form.svelte';
+  import {errorNormalizer} from '../../normalizer/errors';
+  import ServerErrors from '../_components/ServerErrors.svelte';
+
+  export let event;
+  const taskId = event.task ? event.task.id : null;
+  const projectId = event.project ? event.project.id : null;
+  const time = String(event.time);
+
+  let errors = [];
+  let title = `Edition du ${format(new Date(event.date), 'EEEE dd MMMM yyyy', {
+    locale: fr
+  })}`;
+
+  const onSave = async e => {
+    try {
+      await axios.put(`events/${event.id}`, e.detail);
+
+      return goto('/faircalendar');
+    } catch (e) {
+      errors = errorNormalizer(e);
+    }
+  };
+
+  const onDelete = async () => {
+    try {
+      await axios.delete(`events/${event.id}`);
+
+      return goto('/faircalendar');
+    } catch (e) {
+      errors = errorNormalizer(e);
+    }
+  };
+</script>
+
+<svelte:head>
+  <title>Permacoop - {title}</title>
+</svelte:head>
+
+<div class="col-md-12">
+  <Breadcrumb
+    items={[{title: 'FairCalendar', path: 'faircalendar'}, {title: title}]} />
+  <ServerErrors {errors} />
+  <Form on:save={onSave} event={{...event, taskId, projectId, time}}>
+    <button class="btn btn-danger" on:click={onDelete}>Supprimer</button>
+  </Form>
+</div>

--- a/client/src/routes/faircalendar/_Filters.svelte
+++ b/client/src/routes/faircalendar/_Filters.svelte
@@ -1,0 +1,83 @@
+<script>
+  import {createEventDispatcher, onMount} from 'svelte';
+  import {client as axios} from '../../utils/axios';
+  import {subMonths, format, compareDesc, eachMonthOfInterval} from 'date-fns';
+  import {fr} from 'date-fns/locale';
+
+  const dispatch = createEventDispatcher();
+
+  export let userId;
+  export let date;
+
+  let data = [];
+  let periods = eachMonthOfInterval({
+    start: subMonths(new Date(), 6),
+    end: new Date()
+  }).sort(compareDesc);
+
+  onMount(async () => {
+    ({data} = await axios.get('users'));
+  });
+
+  const handleFilter = () => {
+    const filters = {
+      userId,
+      date: format(new Date(date), 'yyyy-MM-dd')
+    };
+
+    const uri = new URLSearchParams(filters).toString();
+    window.history.pushState({}, null, `/faircalendar?${uri}`);
+
+    dispatch('filter', {...filters, date: new Date(date)});
+  };
+</script>
+
+<style>
+  form.filter {
+    background: #e9ecef;
+    padding: 0.75rem 1rem;
+    margin-bottom: 20px;
+    border-radius: 0.25rem;
+  }
+</style>
+
+<form class="filter">
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label for="date">Filtrer par mois :</label>
+        <select
+          id="date"
+          name="date"
+          bind:value={date}
+          on:change={handleFilter}
+          class="form-control">
+          {#each periods as period}
+            <option
+              value={format(period, 'yyyy-MM-dd')}
+              selected={format(period, 'yyyy-MM') === format(new Date(date), 'yyyy-MM')}>
+              {format(period, 'MMMM yyyy', {locale: fr})}
+            </option>
+          {/each}
+        </select>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label for="userId">Filtrer par coopérateur :</label>
+        <select
+          id="userId"
+          name="userId"
+          bind:value={userId}
+          on:change={handleFilter}
+          class="form-control">
+          {#each data as user}
+            <option value={user.id} selected={userId === user.id}>
+              {`${user.lastName} ${user.firstName}`}
+            </option>
+          {/each}
+        </select>
+      </div>
+    </div>
+  </div>
+</form>

--- a/client/src/routes/faircalendar/_Form.svelte
+++ b/client/src/routes/faircalendar/_Form.svelte
@@ -1,0 +1,107 @@
+<script>
+  import {createEventDispatcher, onMount} from 'svelte';
+  import {client as axios} from '../../utils/axios';
+
+  const dispatch = createEventDispatcher();
+
+  let tasks = [];
+  let projects = [];
+
+  onMount(async () => {
+    let [tasksReponse, projectsReponse] = await Promise.all([
+      axios.get('tasks'),
+      axios.get('projects')
+    ]);
+
+    tasks = tasksReponse.data;
+    projects = projectsReponse.data;
+  });
+
+  export let event;
+
+  const submit = () => {
+    dispatch('save', {
+      ...event,
+      date: new Date(event.date)
+    });
+  };
+</script>
+
+<form on:submit|preventDefault={submit}>
+  <div class="form-group">
+    <label for="time">Type *</label>
+    <select
+      id="time"
+      required="required"
+      class="form-control"
+      bind:value={event.type}>
+      <option value={'mission'}>Mission</option>
+      <option value={'dojo'}>Dojo</option>
+      <option value={'support'}>Support // Podcast</option>
+      <option value={'formationConference'}>Formation // Conf // Meetup</option>
+      <option value={'holiday'}>Vacances</option>
+      <option value={'medicalLeave'}>Congé maladie</option>
+      <option value={'other'}>Autre</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="time">Temps passé *</label>
+    <select
+      id="time"
+      required="required"
+      class="form-control"
+      bind:value={event.time}>
+      <option value={'25'}>0.25 jour</option>
+      <option value={'50'}>0.5 jour</option>
+      <option value={'75'}>0.75 jour</option>
+      <option value={'100'}>1 jour</option>
+    </select>
+  </div>
+  {#if event.type === 'mission'}
+    <div class="form-group">
+      <label for="projectId">Projet *</label>
+      <select
+        id="projectId"
+        required="required"
+        class="form-control"
+        bind:value={event.projectId}>
+        <option value="">-- Choisir un projet --</option>
+        {#each projects as project}
+          <option value={project.id} selected={event.projectId === project.id}>
+            {project.name} ({project.customer.name})
+          </option>
+        {/each}
+      </select>
+    </div>
+    <div class="form-group">
+      <label for="taskId">Mission *</label>
+      <select
+        id="taskId"
+        required="required"
+        class="form-control"
+        bind:value={event.taskId}>
+        <option value="">-- Choisir une mission --</option>
+        {#each tasks as task}
+          <option value={task.id} selected={event.taskId === task.id}>
+            {task.name}
+          </option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+  <div class="form-group">
+    <label for="summary">Commentaire</label>
+    <input
+      type="text"
+      id="summary"
+      bind:value={event.summary}
+      class="form-control" />
+  </div>
+  <button
+    type="submit"
+    class="btn btn-primary"
+    disabled={!event.time || !event.type}>
+    Sauvegarder
+  </button>
+  <slot></slot>
+</form>

--- a/client/src/routes/faircalendar/_Overview.svelte
+++ b/client/src/routes/faircalendar/_Overview.svelte
@@ -1,0 +1,43 @@
+<script>
+  export let overview;
+</script>
+
+<div class="mt-3">
+  <hr />
+  <h2 class="display-5">Récapitulatif</h2>
+  <table class="table table-striped table-bordered table-hover ">
+    <thead>
+      <tr>
+        <td class="text-center">Mission</td>
+        <td class="text-center">Support // Podcast</td>
+        <td class="text-center">Dojo</td>
+        <td class="text-center">Formation // Conf // Meetup</td>
+        <td class="text-center">Vacances</td>
+        <td class="text-center">Congé maladie</td>
+        <td class="text-center">Autres</td>
+        <td class="text-center">Tickets Resto</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="text-center">{overview.mission}</td>
+        <td class="text-center">{overview.support}</td>
+        <td class="text-center">{overview.dojo}</td>
+        <td class="text-center">{overview.formationConference}</td>
+        <td class="text-center">{overview.holiday}</td>
+        <td class="text-center">{overview.medicalLeave}</td>
+        <td class="text-center">{overview.other}</td>
+        <td class="text-center">
+          <b>{overview.mealTicket}</b>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="8">
+          Total jour(s) travaillé(s): {overview.totalTimeSpent}
+        </th>
+      </tr>
+    </tfoot>
+  </table>
+</div>

--- a/client/src/routes/faircalendar/index.svelte
+++ b/client/src/routes/faircalendar/index.svelte
@@ -1,0 +1,134 @@
+<script context="module">
+  export const preload = ({query}) => {
+    return {
+      filters: {
+        date: query.date ? new Date(query.date) : new Date(),
+        userId: query.userId ? query.userId : null
+      }
+    };
+  };
+</script>
+
+<script>
+  import {onMount} from 'svelte';
+  import {goto} from '@sapper/app';
+  import frLocale from '@fullcalendar/core/locales/fr';
+  import '@fullcalendar/core/main.css';
+  import '@fullcalendar/daygrid/main.css';
+  import {user} from '../../store';
+  import {client as axios} from '../../utils/axios';
+  import Filters from './_Filters.svelte';
+  import Overview from './_Overview.svelte';
+  import {errorNormalizer} from '../../normalizer/errors';
+  import Breadcrumb from '../_components/Breadcrumb.svelte';
+  import Loader from '../_components/Loader.svelte';
+  import ServerErrors from '../_components/ServerErrors.svelte';
+
+  export let filters;
+
+  let loading = false;
+  let isLoggedUser = false;
+  let errors = [];
+  let data = {};
+
+  const fullCalendar = async (events, date) => {
+    const {Calendar} = await import('@fullcalendar/core');
+    const {default: dayGridPlugin} = await import('@fullcalendar/daygrid');
+    const {default: interactionPlugin} = await import(
+      '@fullcalendar/interaction'
+    );
+
+    const dom = document.getElementById('calendar');
+    dom.innerHTML = '';
+    const calendar = new Calendar(dom, {
+      locale: frLocale,
+      plugins: [dayGridPlugin, interactionPlugin],
+      nowIndicator: true,
+      showNonCurrentDates: false,
+      selectable: true,
+      height: 620,
+      header: {left: 'title', center: '', right: ''},
+      columnHeaderFormat: {weekday: 'long'},
+      events,
+      dateClick: info => {
+        if (!isLoggedUser) {
+          return;
+        }
+
+        goto(`/faircalendar/${info.dateStr}/add`);
+      },
+      eventDataTransform: data => {
+        const {id, date, time, summary, type, task, project} = data;
+        let title = time < 1 ? `[${time}] ` : '';
+
+        if ('mission' === type && task && project) {
+          title += `${project.name} (${task.name})`;
+        } else {
+          title += type;
+        }
+
+        data.id = id;
+        data.title = title;
+        if (isLoggedUser) {
+          data.url = `faircalendar/${id}/edit`;
+        }
+        data.className = `event-${type}`;
+        data.tip = summary;
+      },
+      businessHours: {
+        daysOfWeek: [1, 2, 3, 4, 5]
+      }
+    });
+    calendar.gotoDate(date);
+    calendar.render();
+  };
+
+  const fetchEvents = async params => {
+    try {
+      loading = true;
+      isLoggedUser = params.userId === $user.id;
+      ({data} = await axios.get('events', {params}));
+      fullCalendar(data.events, params.date);
+    } catch (e) {
+      errors = errorNormalizer(e);
+    } finally {
+      loading = false;
+    }
+  };
+
+  onMount(async () => {
+    if (!filters.userId) {
+      filters.userId = $user.id;
+    }
+
+    fetchEvents(filters);
+  });
+
+  const onFilter = e => {
+    fetchEvents(e.detail);
+  };
+</script>
+
+<svelte:head>
+  <title>Permacoop - FairCalendar</title>
+</svelte:head>
+
+<div class="col-md-12">
+  <Breadcrumb items={[{title: 'FairCalendar'}]} />
+  <ServerErrors {errors} />
+  <Filters {...filters} on:filter={onFilter} />
+  <Loader {loading} />
+  <div id="calendar" />
+  <div class="mb-1 mt-2">
+    <span class="badge badge-success">Mission</span>
+    <span class="badge badge-secondary">Support // Podcast</span>
+    <span class="badge badge-info">Dojo</span>
+    <span class="badge badge-warning">Formation // Conf // Meetup</span>
+    <span class="badge badge-primary">Vacances</span>
+    <span class="badge badge-danger">Congé maladie</span>
+    <span class="badge badge-dark">Autres</span>
+  </div>
+  {#if data.overview}
+    <Overview overview={data.overview} />
+  {/if}
+</div>

--- a/client/src/template.html
+++ b/client/src/template.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#343a40" />
     %sapper.base%
     <link rel="stylesheet" href="css/bootstrap.min.css" />
+    <link rel="stylesheet" href="css/fullcalendar.css" />
     <link rel="manifest" href="manifest.json" />
     <link rel="icon" type="image/png" href="images/icons/favicon.ico" />
 

--- a/client/static/css/fullcalendar.css
+++ b/client/static/css/fullcalendar.css
@@ -1,0 +1,45 @@
+.fc-toolbar {
+  margin-bottom: 0.5rem !important;
+}
+.fc-day-header,
+.fc-week-number {
+  padding: 5px !important;
+}
+.fc-event {
+  font-weight: 700;
+}
+.event-mission {
+  color: #fff !important;
+  background-color: #28a745 !important;
+  border-color: #28a745 !important;
+}
+.event-support {
+  color: #fff !important;
+  background-color: #6c757d !important;
+  border-color: #6c757d !important;
+}
+.event-dojo {
+  color: #fff !important;
+  background-color: #17a2b8 !important;
+  border-color: #17a2b8 !important;
+}
+.event-formationConference {
+  color: #212529 !important;
+  background-color: #ffc107 !important;
+  border-color: #ffc107 !important;
+}
+.event-holiday {
+  color: #fff !important;
+  background-color: #007bff !important;
+  border-color: #007bff !important;
+}
+.event-medicalLeave {
+  color: #fff !important;
+  background-color: #dc3545 !important;
+  border-color: #dc3545 !important;
+}
+.event-other {
+  color: #fff !important;
+  background-color: #343a40 !important;
+  border-color: #343a40 !important;
+}

--- a/server/migrations/1587124202585-FairCalendarEvent.ts
+++ b/server/migrations/1587124202585-FairCalendarEvent.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class FairCalendarEvent1587124202585 implements MigrationInterface {
+    name = 'FairCalendarEvent1587124202585'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`CREATE TYPE "event_type_enum" AS ENUM('mission', 'support', 'dojo', 'holiday', 'formationConference', 'workFree', 'medicalLeave', 'other')`, undefined);
+        await queryRunner.query(`CREATE TABLE "event" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "type" "event_type_enum" NOT NULL, "time" integer NOT NULL, "date" date NOT NULL, "summary" character varying, "projectId" uuid, "taskId" uuid, "userId" uuid NOT NULL, CONSTRAINT "PK_30c2f3bbaf6d34a55f8ae6e4614" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`ALTER TABLE "event" ADD CONSTRAINT "FK_3dde39f7b276bbc735a0f762ead" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "event" ADD CONSTRAINT "FK_56b239fecbe385af3a3186acab0" FOREIGN KEY ("taskId") REFERENCES "task"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "event" ADD CONSTRAINT "FK_01cd2b829e0263917bf570cb672" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "event" DROP CONSTRAINT "FK_01cd2b829e0263917bf570cb672"`, undefined);
+        await queryRunner.query(`ALTER TABLE "event" DROP CONSTRAINT "FK_56b239fecbe385af3a3186acab0"`, undefined);
+        await queryRunner.query(`ALTER TABLE "event" DROP CONSTRAINT "FK_3dde39f7b276bbc735a0f762ead"`, undefined);
+        await queryRunner.query(`DROP TABLE "event"`, undefined);
+        await queryRunner.query(`DROP TYPE "event_type_enum"`, undefined);
+    }
+
+}

--- a/server/migrations/1587124202585-FairCalendarEvent.ts
+++ b/server/migrations/1587124202585-FairCalendarEvent.ts
@@ -4,7 +4,7 @@ export class FairCalendarEvent1587124202585 implements MigrationInterface {
     name = 'FairCalendarEvent1587124202585'
 
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(`CREATE TYPE "event_type_enum" AS ENUM('mission', 'support', 'dojo', 'holiday', 'formationConference', 'workFree', 'medicalLeave', 'other')`, undefined);
+        await queryRunner.query(`CREATE TYPE "event_type_enum" AS ENUM('mission', 'support', 'dojo', 'holiday', 'formationConference', 'medicalLeave', 'other')`, undefined);
         await queryRunner.query(`CREATE TABLE "event" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "type" "event_type_enum" NOT NULL, "time" integer NOT NULL, "date" date NOT NULL, "summary" character varying, "projectId" uuid, "taskId" uuid, "userId" uuid NOT NULL, CONSTRAINT "PK_30c2f3bbaf6d34a55f8ae6e4614" PRIMARY KEY ("id"))`, undefined);
         await queryRunner.query(`ALTER TABLE "event" ADD CONSTRAINT "FK_3dde39f7b276bbc735a0f762ead" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
         await queryRunner.query(`ALTER TABLE "event" ADD CONSTRAINT "FK_56b239fecbe385af3a3186acab0" FOREIGN KEY ("taskId") REFERENCES "task"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);

--- a/server/src/Application/FairCalendar/Command/AbstractProjectAndTaskGetter.ts
+++ b/server/src/Application/FairCalendar/Command/AbstractProjectAndTaskGetter.ts
@@ -1,0 +1,39 @@
+import {Task} from 'src/Domain/Task/Task.entity';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {ITaskRepository} from 'src/Domain/Task/Repository/ITaskRepository';
+import {IProjectRepository} from 'src/Domain/Project/Repository/IProjectRepository';
+import {TaskNotFoundException} from 'src/Domain/Task/Exception/TaskNotFoundException';
+import {ProjectNotFoundException} from 'src/Domain/Project/Exception/ProjectNotFoundException';
+
+export abstract class AbstractProjectAndTaskGetter {
+  constructor(
+    private readonly taskRepository: ITaskRepository,
+    private readonly projectRepository: IProjectRepository
+  ) {}
+
+  protected async getTask(taskId?: string): Promise<Task | null> {
+    if (!taskId) {
+      return null;
+    }
+
+    const task = await this.taskRepository.findOneById(taskId);
+    if (!task) {
+      throw new TaskNotFoundException();
+    }
+
+    return task;
+  }
+
+  protected async getProject(projectId?: string): Promise<Project | null> {
+    if (!projectId) {
+      return null;
+    }
+
+    const project = await this.projectRepository.findOneById(projectId);
+    if (!project) {
+      throw new ProjectNotFoundException();
+    }
+
+    return project;
+  }
+}

--- a/server/src/Application/FairCalendar/Command/AddEventCommand.ts
+++ b/server/src/Application/FairCalendar/Command/AddEventCommand.ts
@@ -1,0 +1,15 @@
+import {ICommand} from 'src/Application/ICommand';
+import {User} from 'src/Domain/User/User.entity';
+import {EventType} from 'src/Domain/FairCalendar/Event.entity';
+
+export class AddEventCommand implements ICommand {
+  constructor(
+    public readonly type: EventType,
+    public readonly user: User,
+    public readonly time: number,
+    public readonly date: Date,
+    public readonly projectId?: string,
+    public readonly taskId?: string,
+    public readonly summary?: string
+  ) {}
+}

--- a/server/src/Application/FairCalendar/Command/AddEventCommandHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Command/AddEventCommandHandler.spec.ts
@@ -1,0 +1,254 @@
+import {
+  mock,
+  instance,
+  when,
+  verify,
+  anything,
+  deepEqual,
+  anyOfClass
+} from 'ts-mockito';
+import {TaskRepository} from 'src/Infrastructure/Task/Repository/TaskRepository';
+import {ProjectRepository} from 'src/Infrastructure/Project/Repository/ProjectRepository';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {IsMaximumTimeSpentReached} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached';
+import {AddEventCommandHandler} from './AddEventCommandHandler';
+import {AddEventCommand} from './AddEventCommand';
+import {User} from 'src/Domain/User/User.entity';
+import {ProjectNotFoundException} from 'src/Domain/Project/Exception/ProjectNotFoundException';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {TaskNotFoundException} from 'src/Domain/Task/Exception/TaskNotFoundException';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/MaximumEventReachedException';
+import {Event, EventType} from 'src/Domain/FairCalendar/Event.entity';
+import {DateUtilsAdapter} from 'src/Infrastructure/Adapter/DateUtilsAdapter';
+import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
+
+describe('AddEventCommandHandler', () => {
+  let taskRepository: TaskRepository;
+  let projectRepository: ProjectRepository;
+  let eventRepository: EventRepository;
+  let isMaximumTimeSpentReached: IsMaximumTimeSpentReached;
+  let dateUtils: DateUtilsAdapter;
+  let handler: AddEventCommandHandler;
+
+  const user = mock(User);
+  const project = mock(Project);
+  const task = mock(Task);
+
+  const command = new AddEventCommand(
+    EventType.MISSION,
+    instance(user),
+    100,
+    new Date('2019-12-12'),
+    '50e624ef-3609-4053-a437-f74844a2d2de',
+    'e3fc9666-2932-4dc1-b2b9-d904388293fb',
+    'Superkaiser development'
+  );
+
+  beforeEach(() => {
+    taskRepository = mock(TaskRepository);
+    projectRepository = mock(ProjectRepository);
+    eventRepository = mock(EventRepository);
+    taskRepository = mock(TaskRepository);
+    isMaximumTimeSpentReached = mock(IsMaximumTimeSpentReached);
+    dateUtils = mock(DateUtilsAdapter);
+
+    handler = new AddEventCommandHandler(
+      instance(taskRepository),
+      instance(projectRepository),
+      instance(eventRepository),
+      instance(dateUtils),
+      instance(isMaximumTimeSpentReached)
+    );
+  });
+
+  it('testProjectOrTaskMissing', async () => {
+    try {
+      await handler.execute(
+        new AddEventCommand(
+          EventType.MISSION,
+          instance(user),
+          100,
+          new Date('2019-12-12')
+        )
+      );
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProjectOrTaskMissingException);
+      expect(e.message).toBe('fair_calendar.errors.project_or_task_missing');
+      verify(projectRepository.findOneById(anything())).never();
+      verify(taskRepository.findOneById(anything())).never();
+      verify(isMaximumTimeSpentReached.isSatisfiedBy(anything())).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testProjectNotFound', async () => {
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProjectNotFoundException);
+      expect(e.message).toBe('project.errors.not_found');
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(taskRepository.findOneById(anything())).never();
+      verify(isMaximumTimeSpentReached.isSatisfiedBy(anything())).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testTaskNotFound', async () => {
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(TaskNotFoundException);
+      expect(e.message).toBe('task.errors.not_found');
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(
+        taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+      ).once();
+      verify(isMaximumTimeSpentReached.isSatisfiedBy(anything())).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testMaximumTimeSpentReached', async () => {
+    const event = new Event(
+      EventType.MISSION,
+      instance(user),
+      100,
+      '2019-12-12',
+      instance(project),
+      instance(task),
+      'Superkaiser development'
+    );
+
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(instance(task));
+    when(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).thenResolve(
+      true
+    );
+    when(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).thenReturn(
+      '2019-12-12'
+    );
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(MaximumEventReachedException);
+      expect(e.message).toBe('fair_calendar.errors.event_maximum_reached');
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(
+        taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+      ).once();
+      verify(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).once();
+      verify(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).once();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testMissionAddedSuccessfully', async () => {
+    const event = new Event(
+      EventType.MISSION,
+      instance(user),
+      100,
+      '2019-12-12',
+      instance(project),
+      instance(task),
+      'Superkaiser development'
+    );
+    const savedEvent = mock(Event);
+
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(instance(task));
+    when(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).thenResolve(
+      false
+    );
+    when(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).thenReturn(
+      '2019-12-12'
+    );
+    when(savedEvent.getId()).thenReturn('a2eaac9c-a118-4502-bc9f-4dbd3b296e73');
+    when(eventRepository.save(deepEqual(event))).thenResolve(
+      instance(savedEvent)
+    );
+
+    expect(await handler.execute(command)).toBe(
+      'a2eaac9c-a118-4502-bc9f-4dbd3b296e73'
+    );
+
+    verify(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).once();
+    verify(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).once();
+    verify(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).once();
+    verify(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).once();
+    verify(eventRepository.save(deepEqual(event))).once();
+    verify(savedEvent.getId()).once();
+  });
+
+  it('testHollidayAddedSuccessfully', async () => {
+    const event = new Event(
+      EventType.HOLIDAY,
+      instance(user),
+      100,
+      '2019-12-12',
+      null,
+      null
+    );
+    const savedEvent = mock(Event);
+
+    when(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).thenResolve(
+      false
+    );
+    when(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).thenReturn(
+      '2019-12-12'
+    );
+    when(savedEvent.getId()).thenReturn('a2eaac9c-a118-4502-bc9f-4dbd3b296e73');
+    when(eventRepository.save(deepEqual(event))).thenResolve(
+      instance(savedEvent)
+    );
+
+    expect(
+      await handler.execute(
+        new AddEventCommand(
+          EventType.HOLIDAY,
+          instance(user),
+          100,
+          new Date('2019-12-12')
+        )
+      )
+    ).toBe('a2eaac9c-a118-4502-bc9f-4dbd3b296e73');
+
+    verify(projectRepository.findOneById(anything())).never();
+    verify(taskRepository.findOneById(anything())).never();
+    verify(dateUtils.format(anyOfClass(Date), 'y-MM-dd')).once();
+    verify(isMaximumTimeSpentReached.isSatisfiedBy(deepEqual(event))).once();
+    verify(eventRepository.save(deepEqual(event))).once();
+    verify(savedEvent.getId()).once();
+  });
+});

--- a/server/src/Application/FairCalendar/Command/AddEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/AddEventCommandHandler.ts
@@ -1,0 +1,55 @@
+import {CommandHandler} from '@nestjs/cqrs';
+import {Inject} from '@nestjs/common';
+import {AddEventCommand} from './AddEventCommand';
+import {ITaskRepository} from 'src/Domain/Task/Repository/ITaskRepository';
+import {IProjectRepository} from 'src/Domain/Project/Repository/IProjectRepository';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {IsMaximumTimeSpentReached} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached';
+import {Event, EventType} from 'src/Domain/FairCalendar/Event.entity';
+import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/MaximumEventReachedException';
+import {IDateUtils} from 'src/Application/IDateUtils';
+import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
+import {AbstractProjectAndTaskGetter} from './AbstractProjectAndTaskGetter';
+
+@CommandHandler(AddEventCommand)
+export class AddEventCommandHandler extends AbstractProjectAndTaskGetter {
+  constructor(
+    @Inject('ITaskRepository') taskRepository: ITaskRepository,
+    @Inject('IProjectRepository') projectRepository: IProjectRepository,
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository,
+    @Inject('IDateUtils')
+    private readonly dateUtils: IDateUtils,
+    private readonly isMaximumTimeSpentReached: IsMaximumTimeSpentReached
+  ) {
+    super(taskRepository, projectRepository);
+  }
+
+  public async execute(command: AddEventCommand): Promise<string> {
+    const {type, date, projectId, taskId, summary, time, user} = command;
+
+    if (type === EventType.MISSION && (!projectId || !taskId)) {
+      throw new ProjectOrTaskMissingException();
+    }
+
+    const project = await this.getProject(projectId);
+    const task = await this.getTask(taskId);
+    const event = new Event(
+      type,
+      user,
+      time,
+      this.dateUtils.format(date, 'y-MM-dd'),
+      project,
+      task,
+      summary
+    );
+
+    if (true === (await this.isMaximumTimeSpentReached.isSatisfiedBy(event))) {
+      throw new MaximumEventReachedException();
+    }
+
+    const savedEvent = await this.eventRepository.save(event);
+
+    return savedEvent.getId();
+  }
+}

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommand.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommand.ts
@@ -1,0 +1,6 @@
+import {ICommand} from 'src/Application/ICommand';
+import {User} from 'src/Domain/User/User.entity';
+
+export class DeleteEventCommand implements ICommand {
+  constructor(public readonly id: string, public readonly user: User) {}
+}

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.spec.ts
@@ -1,0 +1,102 @@
+import {mock, instance, when, verify, anything, deepEqual} from 'ts-mockito';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {DeleteEventCommandHandler} from './DeleteEventCommandHandler';
+import {DeleteEventCommand} from './DeleteEventCommand';
+import {User} from 'src/Domain/User/User.entity';
+import {Event, EventType} from 'src/Domain/FairCalendar/Event.entity';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+
+describe('DeleteEventCommandHandler', () => {
+  let eventRepository: EventRepository;
+  let isEventBelongToUser: IsEventBelongToUser;
+  let handler: DeleteEventCommandHandler;
+
+  const user = mock(User);
+  const project = mock(Project);
+  const task = mock(Task);
+  const event = new Event(
+    EventType.MISSION,
+    instance(user),
+    100,
+    '2020-05-15',
+    instance(project),
+    instance(task),
+    'summary'
+  );
+
+  const command = new DeleteEventCommand(
+    '50e624ef-3609-4053-a437-f74844a2d2de',
+    instance(user)
+  );
+
+  beforeEach(() => {
+    eventRepository = mock(EventRepository);
+    isEventBelongToUser = mock(IsEventBelongToUser);
+    handler = new DeleteEventCommandHandler(
+      instance(eventRepository),
+      instance(isEventBelongToUser)
+    );
+  });
+
+  it('testEventNotFound', async () => {
+    when(
+      eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventNotFoundException);
+      expect(e.message).toBe('fair_calendar.errors.event_not_found');
+      verify(
+        eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(isEventBelongToUser.isSatisfiedBy(anything(), anything())).never();
+      verify(eventRepository.delete(anything())).never();
+    }
+  });
+
+  it('testNotEventOwner', async () => {
+    when(
+      eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(event);
+    when(isEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
+      false
+    );
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventDoesntBelongToUserException);
+      expect(e.message).toBe(
+        'fair_calendar.errors.event_doesnt_belong_to_user'
+      );
+      verify(
+        eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(isEventBelongToUser.isSatisfiedBy(event, instance(user))).once();
+      verify(eventRepository.delete(anything())).never();
+    }
+  });
+
+  it('testDeleteEvent', async () => {
+    when(
+      eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(event);
+    when(isEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
+      true
+    );
+    when(user.getId()).thenReturn('e3fc9666-2932-4dc1-b2b9-d904388293fb');
+
+    expect(await handler.execute(command));
+
+    verify(
+      eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).once();
+    verify(eventRepository.delete(deepEqual(event))).once();
+  });
+});

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.spec.ts
@@ -8,11 +8,11 @@ import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNot
 import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
 import {Project} from 'src/Domain/Project/Project.entity';
 import {Task} from 'src/Domain/Task/Task.entity';
-import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {DoesEventBelongToUser} from 'src/Domain/FairCalendar/Specification/DoesEventBelongToUser';
 
 describe('DeleteEventCommandHandler', () => {
   let eventRepository: EventRepository;
-  let isEventBelongToUser: IsEventBelongToUser;
+  let doesEventBelongToUser: DoesEventBelongToUser;
   let handler: DeleteEventCommandHandler;
 
   const user = mock(User);
@@ -35,10 +35,10 @@ describe('DeleteEventCommandHandler', () => {
 
   beforeEach(() => {
     eventRepository = mock(EventRepository);
-    isEventBelongToUser = mock(IsEventBelongToUser);
+    doesEventBelongToUser = mock(DoesEventBelongToUser);
     handler = new DeleteEventCommandHandler(
       instance(eventRepository),
-      instance(isEventBelongToUser)
+      instance(doesEventBelongToUser)
     );
   });
 
@@ -55,7 +55,9 @@ describe('DeleteEventCommandHandler', () => {
       verify(
         eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
       ).once();
-      verify(isEventBelongToUser.isSatisfiedBy(anything(), anything())).never();
+      verify(
+        doesEventBelongToUser.isSatisfiedBy(anything(), anything())
+      ).never();
       verify(eventRepository.delete(anything())).never();
     }
   });
@@ -64,7 +66,7 @@ describe('DeleteEventCommandHandler', () => {
     when(
       eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
     ).thenResolve(event);
-    when(isEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
+    when(doesEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
       false
     );
 
@@ -78,7 +80,7 @@ describe('DeleteEventCommandHandler', () => {
       verify(
         eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
       ).once();
-      verify(isEventBelongToUser.isSatisfiedBy(event, instance(user))).once();
+      verify(doesEventBelongToUser.isSatisfiedBy(event, instance(user))).once();
       verify(eventRepository.delete(anything())).never();
     }
   });
@@ -87,7 +89,7 @@ describe('DeleteEventCommandHandler', () => {
     when(
       eventRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
     ).thenResolve(event);
-    when(isEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
+    when(doesEventBelongToUser.isSatisfiedBy(event, instance(user))).thenReturn(
       true
     );
     when(user.getId()).thenReturn('e3fc9666-2932-4dc1-b2b9-d904388293fb');

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
@@ -26,6 +26,6 @@ export class DeleteEventCommandHandler {
       throw new EventDoesntBelongToUserException();
     }
 
-    this.eventRepository.delete(event);
+    await this.eventRepository.delete(event);
   }
 }

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
@@ -1,0 +1,31 @@
+import {CommandHandler} from '@nestjs/cqrs';
+import {Inject} from '@nestjs/common';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {DeleteEventCommand} from './DeleteEventCommand';
+import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+
+@CommandHandler(DeleteEventCommand)
+export class DeleteEventCommandHandler {
+  constructor(
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository,
+    private readonly isEventOwnedByUser: IsEventBelongToUser
+  ) {}
+
+  public async execute(command: DeleteEventCommand): Promise<void> {
+    const {id, user} = command;
+    const event = await this.eventRepository.findOneById(id);
+
+    if (!event) {
+      throw new EventNotFoundException();
+    }
+
+    if (false === this.isEventOwnedByUser.isSatisfiedBy(event, user)) {
+      throw new EventDoesntBelongToUserException();
+    }
+
+    this.eventRepository.delete(event);
+  }
+}

--- a/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/DeleteEventCommandHandler.ts
@@ -4,14 +4,14 @@ import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventReposit
 import {DeleteEventCommand} from './DeleteEventCommand';
 import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
 import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
-import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {DoesEventBelongToUser} from 'src/Domain/FairCalendar/Specification/DoesEventBelongToUser';
 
 @CommandHandler(DeleteEventCommand)
 export class DeleteEventCommandHandler {
   constructor(
     @Inject('IEventRepository')
     private readonly eventRepository: IEventRepository,
-    private readonly isEventOwnedByUser: IsEventBelongToUser
+    private readonly doesEventBelongToUser: DoesEventBelongToUser
   ) {}
 
   public async execute(command: DeleteEventCommand): Promise<void> {
@@ -22,7 +22,7 @@ export class DeleteEventCommandHandler {
       throw new EventNotFoundException();
     }
 
-    if (false === this.isEventOwnedByUser.isSatisfiedBy(event, user)) {
+    if (false === this.doesEventBelongToUser.isSatisfiedBy(event, user)) {
       throw new EventDoesntBelongToUserException();
     }
 

--- a/server/src/Application/FairCalendar/Command/UpdateEventCommand.ts
+++ b/server/src/Application/FairCalendar/Command/UpdateEventCommand.ts
@@ -1,0 +1,15 @@
+import {ICommand} from 'src/Application/ICommand';
+import {User} from 'src/Domain/User/User.entity';
+import {EventType} from 'src/Domain/FairCalendar/Event.entity';
+
+export class UpdateEventCommand implements ICommand {
+  constructor(
+    public readonly id: string,
+    public readonly user: User,
+    public readonly type: EventType,
+    public readonly time: number,
+    public readonly projectId?: string,
+    public readonly taskId?: string,
+    public readonly summary?: string
+  ) {}
+}

--- a/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.spec.ts
@@ -1,0 +1,259 @@
+import {mock, instance, when, verify, anything} from 'ts-mockito';
+import {TaskRepository} from 'src/Infrastructure/Task/Repository/TaskRepository';
+import {ProjectRepository} from 'src/Infrastructure/Project/Repository/ProjectRepository';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {UpdateEventCommandHandler} from './UpdateEventCommandHandler';
+import {UpdateEventCommand} from './UpdateEventCommand';
+import {User} from 'src/Domain/User/User.entity';
+import {ProjectNotFoundException} from 'src/Domain/Project/Exception/ProjectNotFoundException';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {TaskNotFoundException} from 'src/Domain/Task/Exception/TaskNotFoundException';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/MaximumEventReachedException';
+import {Event, EventType} from 'src/Domain/FairCalendar/Event.entity';
+import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
+import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+
+describe('UpdateEventCommandHandler', () => {
+  let taskRepository: TaskRepository;
+  let projectRepository: ProjectRepository;
+  let eventRepository: EventRepository;
+  let isEventBelongToUser: IsEventBelongToUser;
+  let isMaximumTimeSpentReachedOnEdition: IsMaximumTimeSpentReachedOnEdition;
+  let handler: UpdateEventCommandHandler;
+
+  const event = mock(Event);
+  const user = mock(User);
+  const project = mock(Project);
+  const task = mock(Task);
+
+  const command = new UpdateEventCommand(
+    '5a18fde0-07d9-4854-a6da-c3ad2de76bd7',
+    instance(user),
+    EventType.MISSION,
+    100,
+    '50e624ef-3609-4053-a437-f74844a2d2de',
+    'e3fc9666-2932-4dc1-b2b9-d904388293fb',
+    'Superkaiser development'
+  );
+
+  beforeEach(() => {
+    taskRepository = mock(TaskRepository);
+    projectRepository = mock(ProjectRepository);
+    eventRepository = mock(EventRepository);
+    taskRepository = mock(TaskRepository);
+    isEventBelongToUser = mock(IsEventBelongToUser);
+    isMaximumTimeSpentReachedOnEdition = mock(
+      IsMaximumTimeSpentReachedOnEdition
+    );
+
+    handler = new UpdateEventCommandHandler(
+      instance(taskRepository),
+      instance(projectRepository),
+      instance(eventRepository),
+      instance(isEventBelongToUser),
+      instance(isMaximumTimeSpentReachedOnEdition)
+    );
+  });
+
+  it('testEventNotFound', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventNotFoundException);
+      expect(e.message).toBe('fair_calendar.errors.event_not_found');
+      verify(
+        eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+      ).once();
+      verify(projectRepository.findOneById(anything())).never();
+      verify(taskRepository.findOneById(anything())).never();
+      verify(
+        isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(anything(), anything())
+      ).never();
+      verify(
+        event.update(anything(), anything(), anything(), anything(), anything())
+      ).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testProjectOrTaskMissing', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(instance(event));
+
+    try {
+      await handler.execute(
+        new UpdateEventCommand(
+          '5a18fde0-07d9-4854-a6da-c3ad2de76bd7',
+          instance(user),
+          EventType.MISSION,
+          100
+        )
+      );
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProjectOrTaskMissingException);
+      expect(e.message).toBe('fair_calendar.errors.project_or_task_missing');
+      verify(
+        eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+      ).once();
+      verify(projectRepository.findOneById(anything())).never();
+      verify(taskRepository.findOneById(anything())).never();
+      verify(
+        isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(anything(), anything())
+      ).never();
+      verify(
+        event.update(anything(), anything(), anything(), anything(), anything())
+      ).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testProjectNotFound', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(instance(event));
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProjectNotFoundException);
+      expect(e.message).toBe('project.errors.not_found');
+      verify(
+        eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+      ).once();
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(taskRepository.findOneById(anything())).never();
+      verify(
+        isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(anything(), anything())
+      ).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testTaskNotFound', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(instance(event));
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(null);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(TaskNotFoundException);
+      expect(e.message).toBe('task.errors.not_found');
+      verify(
+        eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+      ).once();
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(
+        taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+      ).once();
+      verify(
+        isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(anything(), anything())
+      ).never();
+      verify(
+        event.update(anything(), anything(), anything(), anything(), anything())
+      ).never();
+      verify(eventRepository.save(anything())).never();
+    }
+  });
+
+  it('testMaximumTimeSpentReached', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(instance(event));
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(instance(task));
+    when(
+      isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(instance(event), 100)
+    ).thenResolve(true);
+
+    try {
+      await handler.execute(command);
+    } catch (e) {
+      expect(e).toBeInstanceOf(MaximumEventReachedException);
+      expect(e.message).toBe('fair_calendar.errors.event_maximum_reached');
+      verify(
+        eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+      ).once();
+      verify(
+        projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+      ).once();
+      verify(
+        taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+      ).once();
+      verify(
+        isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(instance(event), 100)
+      ).once();
+      verify(eventRepository.save(anything())).never();
+      verify(
+        event.update(anything(), anything(), anything(), anything(), anything())
+      ).never();
+    }
+  });
+
+  it('testUpdatedSuccessfully', async () => {
+    when(
+      eventRepository.findOneById('5a18fde0-07d9-4854-a6da-c3ad2de76bd7')
+    ).thenResolve(instance(event));
+    when(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).thenResolve(instance(project));
+    when(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).thenResolve(instance(task));
+    when(
+      isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(instance(event), 100)
+    ).thenResolve(false);
+    when(event.getId()).thenReturn('a2eaac9c-a118-4502-bc9f-4dbd3b296e73');
+    when(eventRepository.save(instance(event))).thenResolve(instance(event));
+
+    expect(await handler.execute(command)).toBe(
+      'a2eaac9c-a118-4502-bc9f-4dbd3b296e73'
+    );
+
+    verify(
+      projectRepository.findOneById('50e624ef-3609-4053-a437-f74844a2d2de')
+    ).once();
+    verify(
+      taskRepository.findOneById('e3fc9666-2932-4dc1-b2b9-d904388293fb')
+    ).once();
+    verify(
+      isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(instance(event), 100)
+    ).once();
+    verify(
+      event.update(
+        EventType.MISSION,
+        100,
+        instance(project),
+        instance(task),
+        'Superkaiser development'
+      )
+    ).calledBefore(eventRepository.save(instance(event)));
+    verify(eventRepository.save(instance(event))).once();
+    verify(event.getId()).once();
+  });
+});

--- a/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.spec.ts
@@ -12,7 +12,7 @@ import {Task} from 'src/Domain/Task/Task.entity';
 import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/MaximumEventReachedException';
 import {Event, EventType} from 'src/Domain/FairCalendar/Event.entity';
 import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
-import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {DoesEventBelongToUser} from 'src/Domain/FairCalendar/Specification/DoesEventBelongToUser';
 import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
 import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
 
@@ -20,7 +20,7 @@ describe('UpdateEventCommandHandler', () => {
   let taskRepository: TaskRepository;
   let projectRepository: ProjectRepository;
   let eventRepository: EventRepository;
-  let isEventBelongToUser: IsEventBelongToUser;
+  let doesEventBelongToUser: DoesEventBelongToUser;
   let isMaximumTimeSpentReachedOnEdition: IsMaximumTimeSpentReachedOnEdition;
   let handler: UpdateEventCommandHandler;
 
@@ -44,7 +44,7 @@ describe('UpdateEventCommandHandler', () => {
     projectRepository = mock(ProjectRepository);
     eventRepository = mock(EventRepository);
     taskRepository = mock(TaskRepository);
-    isEventBelongToUser = mock(IsEventBelongToUser);
+    doesEventBelongToUser = mock(DoesEventBelongToUser);
     isMaximumTimeSpentReachedOnEdition = mock(
       IsMaximumTimeSpentReachedOnEdition
     );
@@ -53,7 +53,7 @@ describe('UpdateEventCommandHandler', () => {
       instance(taskRepository),
       instance(projectRepository),
       instance(eventRepository),
-      instance(isEventBelongToUser),
+      instance(doesEventBelongToUser),
       instance(isMaximumTimeSpentReachedOnEdition)
     );
   });

--- a/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.ts
@@ -9,7 +9,7 @@ import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/Ma
 import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
 import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
 import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
-import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {DoesEventBelongToUser} from 'src/Domain/FairCalendar/Specification/DoesEventBelongToUser';
 import {AbstractProjectAndTaskGetter} from './AbstractProjectAndTaskGetter';
 import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
 
@@ -20,7 +20,7 @@ export class UpdateEventCommandHandler extends AbstractProjectAndTaskGetter {
     @Inject('IProjectRepository') projectRepository: IProjectRepository,
     @Inject('IEventRepository')
     private readonly eventRepository: IEventRepository,
-    private readonly isEventBelongToUser: IsEventBelongToUser,
+    private readonly doesEventBelongToUser: DoesEventBelongToUser,
     private readonly isMaximumTimeSpentReachedOnEdition: IsMaximumTimeSpentReachedOnEdition
   ) {
     super(taskRepository, projectRepository);
@@ -34,7 +34,7 @@ export class UpdateEventCommandHandler extends AbstractProjectAndTaskGetter {
       throw new EventNotFoundException();
     }
 
-    if (false === this.isEventBelongToUser.isSatisfiedBy(event, user)) {
+    if (false === this.doesEventBelongToUser.isSatisfiedBy(event, user)) {
       throw new EventDoesntBelongToUserException();
     }
 

--- a/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/UpdateEventCommandHandler.ts
@@ -1,0 +1,60 @@
+import {CommandHandler} from '@nestjs/cqrs';
+import {Inject} from '@nestjs/common';
+import {UpdateEventCommand} from './UpdateEventCommand';
+import {ITaskRepository} from 'src/Domain/Task/Repository/ITaskRepository';
+import {IProjectRepository} from 'src/Domain/Project/Repository/IProjectRepository';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {EventType} from 'src/Domain/FairCalendar/Event.entity';
+import {MaximumEventReachedException} from 'src/Domain/FairCalendar/Exception/MaximumEventReachedException';
+import {ProjectOrTaskMissingException} from 'src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+import {EventDoesntBelongToUserException} from 'src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException';
+import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {AbstractProjectAndTaskGetter} from './AbstractProjectAndTaskGetter';
+import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
+
+@CommandHandler(UpdateEventCommand)
+export class UpdateEventCommandHandler extends AbstractProjectAndTaskGetter {
+  constructor(
+    @Inject('ITaskRepository') taskRepository: ITaskRepository,
+    @Inject('IProjectRepository') projectRepository: IProjectRepository,
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository,
+    private readonly isEventBelongToUser: IsEventBelongToUser,
+    private readonly isMaximumTimeSpentReachedOnEdition: IsMaximumTimeSpentReachedOnEdition
+  ) {
+    super(taskRepository, projectRepository);
+  }
+
+  public async execute(command: UpdateEventCommand): Promise<string> {
+    const {id, type, projectId, taskId, summary, time, user} = command;
+
+    const event = await this.eventRepository.findOneById(id);
+    if (!event) {
+      throw new EventNotFoundException();
+    }
+
+    if (false === this.isEventBelongToUser.isSatisfiedBy(event, user)) {
+      throw new EventDoesntBelongToUserException();
+    }
+
+    if (type === EventType.MISSION && (!projectId || !taskId)) {
+      throw new ProjectOrTaskMissingException();
+    }
+
+    const project = await this.getProject(projectId);
+    const task = await this.getTask(taskId);
+
+    if (
+      true ===
+      (await this.isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(event, time))
+    ) {
+      throw new MaximumEventReachedException();
+    }
+
+    event.update(type, time, project, task, summary);
+    await this.eventRepository.save(event);
+
+    return event.getId();
+  }
+}

--- a/server/src/Application/FairCalendar/Query/GetEventByIdQuery.ts
+++ b/server/src/Application/FairCalendar/Query/GetEventByIdQuery.ts
@@ -1,0 +1,5 @@
+import {IQuery} from 'src/Application/IQuery';
+
+export class GetEventByIdQuery implements IQuery {
+  constructor(public readonly id: string) {}
+}

--- a/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.spec.ts
@@ -21,7 +21,7 @@ describe('GetEventByIdQueryHandler', () => {
     const expectedResult = new EventView(
       'eb9e1d9b-dce2-48a9-b64f-f0872f3157d2',
       'mission',
-      0.75,
+      75,
       '2019-12-12',
       'Summary',
       new ProjectView('bf4a645c-9754-4943-baec-783361c6d814', 'RadioFrance'),

--- a/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.spec.ts
@@ -1,0 +1,78 @@
+import {mock, instance, when, verify} from 'ts-mockito';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {Event} from 'src/Domain/FairCalendar/Event.entity';
+import {EventView} from 'src/Application/FairCalendar/View/EventView';
+import {GetEventByIdQueryHandler} from './GetEventByIdQueryHandler';
+import {GetEventByIdQuery} from './GetEventByIdQuery';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {ProjectView} from 'src/Application/Project/View/ProjectView';
+import {TaskView} from 'src/Application/Task/View/TaskView';
+
+describe('GetEventByIdQueryHandler', () => {
+  const query = new GetEventByIdQuery('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2');
+
+  it('testGetEvent', async () => {
+    const eventRepository = mock(EventRepository);
+    const queryHandler = new GetEventByIdQueryHandler(
+      instance(eventRepository)
+    );
+    const expectedResult = new EventView(
+      'eb9e1d9b-dce2-48a9-b64f-f0872f3157d2',
+      'mission',
+      0.75,
+      '2019-12-12',
+      'Summary',
+      new ProjectView('bf4a645c-9754-4943-baec-783361c6d814', 'RadioFrance'),
+      new TaskView('7fb77f06-2d0b-4758-886a-42bba5445fcd', 'Development')
+    );
+
+    const task = mock(Task);
+    const project = mock(Project);
+
+    when(project.getId()).thenReturn('bf4a645c-9754-4943-baec-783361c6d814');
+    when(project.getName()).thenReturn('RadioFrance');
+    when(task.getId()).thenReturn('7fb77f06-2d0b-4758-886a-42bba5445fcd');
+    when(task.getName()).thenReturn('Development');
+
+    const event1 = mock(Event);
+    when(event1.getId()).thenReturn('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2');
+    when(event1.getType()).thenReturn('mission');
+    when(event1.getTime()).thenReturn(75);
+    when(event1.getDate()).thenReturn('2019-12-12');
+    when(event1.getSummary()).thenReturn('Summary');
+    when(event1.getTask()).thenReturn(instance(task));
+    when(event1.getProject()).thenReturn(instance(project));
+
+    when(
+      eventRepository.findOneById('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2')
+    ).thenResolve(instance(event1));
+
+    expect(await queryHandler.execute(query)).toMatchObject(expectedResult);
+
+    verify(
+      eventRepository.findOneById('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2')
+    ).once();
+  });
+
+  it('testGetEventNotFound', async () => {
+    const eventRepository = mock(EventRepository);
+    const queryHandler = new GetEventByIdQueryHandler(
+      instance(eventRepository)
+    );
+    when(
+      eventRepository.findOneById('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2')
+    ).thenResolve(null);
+
+    try {
+      await queryHandler.execute(query);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventNotFoundException);
+      expect(e.message).toBe('fair_calendar.errors.event_not_found');
+      verify(
+        eventRepository.findOneById('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2')
+      ).once();
+    }
+  });
+});

--- a/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.ts
+++ b/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.ts
@@ -1,0 +1,36 @@
+import {QueryHandler} from '@nestjs/cqrs';
+import {Inject} from '@nestjs/common';
+import {GetEventByIdQuery} from './GetEventByIdQuery';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {EventView} from '../View/EventView';
+import {EventNotFoundException} from 'src/Domain/FairCalendar/Exception/EventNotFoundException';
+import {ProjectView} from 'src/Application/Project/View/ProjectView';
+import {TaskView} from 'src/Application/Task/View/TaskView';
+
+@QueryHandler(GetEventByIdQuery)
+export class GetEventByIdQueryHandler {
+  constructor(
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository
+  ) {}
+
+  public async execute(query: GetEventByIdQuery): Promise<EventView> {
+    const event = await this.eventRepository.findOneById(query.id);
+    if (!event) {
+      throw new EventNotFoundException();
+    }
+
+    const project = event.getProject();
+    const task = event.getTask();
+
+    return new EventView(
+      event.getId(),
+      event.getType(),
+      event.getTime() / 100,
+      event.getDate(),
+      event.getSummary(),
+      project ? new ProjectView(project.getId(), project.getName()) : null,
+      task ? new TaskView(task.getId(), task.getName()) : null
+    );
+  }
+}

--- a/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.ts
+++ b/server/src/Application/FairCalendar/Query/GetEventByIdQueryHandler.ts
@@ -26,7 +26,7 @@ export class GetEventByIdQueryHandler {
     return new EventView(
       event.getId(),
       event.getType(),
-      event.getTime() / 100,
+      event.getTime(),
       event.getDate(),
       event.getSummary(),
       project ? new ProjectView(project.getId(), project.getName()) : null,

--- a/server/src/Application/FairCalendar/Query/GetMonthlyEventsQuery.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyEventsQuery.ts
@@ -1,0 +1,5 @@
+import {IQuery} from 'src/Application/IQuery';
+
+export class GetMonthlyEventsQuery implements IQuery {
+  constructor(public readonly date: Date, public readonly userId: string) {}
+}

--- a/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.spec.ts
@@ -1,0 +1,150 @@
+import {mock, instance, when, verify, deepEqual} from 'ts-mockito';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {GetMonthlyEventsQueryHandler} from './GetMonthlyEventsQueryHandler';
+import {GetMonthlyEventsQuery} from './GetMonthlyEventsQuery';
+import {EventView} from '../View/EventView';
+import {DateUtilsAdapter} from 'src/Infrastructure/Adapter/DateUtilsAdapter';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {Event} from 'src/Domain/FairCalendar/Event.entity';
+import {GetEventsOverview} from 'src/Domain/FairCalendar/GetEventsOverview';
+import {MonthlyEventsView} from '../View/MonthlyEventsView';
+import {IEventsOverview} from 'src/Domain/FairCalendar/IEventsOverview';
+import {ProjectView} from 'src/Application/Project/View/ProjectView';
+import {TaskView} from 'src/Application/Task/View/TaskView';
+
+describe('GetMonthlyEventsQueryHandler', () => {
+  it('testGetEvents', async () => {
+    const eventRepository = mock(EventRepository);
+    const dateUtils = mock(DateUtilsAdapter);
+    const getEventsOverview = mock(GetEventsOverview);
+    const task = mock(Task);
+    const project = mock(Project);
+
+    when(project.getId()).thenReturn('bf4a645c-9754-4943-baec-783361c6d814');
+    when(project.getName()).thenReturn('RadioFrance');
+    when(task.getId()).thenReturn('7fb77f06-2d0b-4758-886a-42bba5445fcd');
+    when(task.getName()).thenReturn('Development');
+
+    const event1 = mock(Event);
+    when(event1.getId()).thenReturn('eb9e1d9b-dce2-48a9-b64f-f0872f3157d2');
+    when(event1.getType()).thenReturn('mission');
+    when(event1.getTime()).thenReturn(75);
+    when(event1.getDate()).thenReturn('2019-12-12');
+    when(event1.getSummary()).thenReturn('Summary');
+    when(event1.getTask()).thenReturn(instance(task));
+    when(event1.getProject()).thenReturn(instance(project));
+
+    const event2 = mock(Event);
+    when(event2.getId()).thenReturn('b9a9b094-5bb2-4d0b-b01e-231b6cb50039');
+    when(event2.getType()).thenReturn('dojo');
+    when(event2.getTime()).thenReturn(25);
+    when(event2.getDate()).thenReturn('2019-12-12');
+    when(event2.getSummary()).thenReturn(null);
+    when(event2.getTask()).thenReturn(null);
+    when(event2.getProject()).thenReturn(null);
+
+    const event3 = mock(Event);
+    when(event3.getId()).thenReturn('a773a25d-8028-4190-bc03-51b33a0d1528');
+    when(event3.getType()).thenReturn('holiday');
+    when(event3.getDate()).thenReturn('2019-12-17');
+    when(event3.getTime()).thenReturn(100);
+    when(event3.getSummary()).thenReturn(null);
+    when(event3.getTask()).thenReturn(null);
+    when(event3.getProject()).thenReturn(null);
+
+    const overview: IEventsOverview = {
+      mission: 0.75,
+      dojo: 0.25,
+      formationConference: 0,
+      holiday: 1,
+      medicalLeave: 0,
+      support: 0,
+      workFree: 0,
+      other: 0,
+      mealTicket: 1,
+      totalTimeSpent: 1
+    };
+
+    const events = [instance(event1), instance(event2), instance(event3)];
+
+    when(
+      dateUtils.format(
+        deepEqual(new Date(`2019-12-12T17:43:14.299Z`)),
+        'y-MM-dd'
+      )
+    ).thenReturn(`2019-12-12`);
+    when(
+      eventRepository.findMonthlyEvents(
+        '2019-12-12',
+        '00bef1e1-cb52-4914-8887-568b17d99964'
+      )
+    ).thenResolve(events);
+    when(getEventsOverview.index(events)).thenReturn(overview);
+
+    const queryHandler = new GetMonthlyEventsQueryHandler(
+      instance(eventRepository),
+      instance(dateUtils),
+      instance(getEventsOverview)
+    );
+
+    expect(
+      await queryHandler.execute(
+        new GetMonthlyEventsQuery(
+          new Date('2019-12-12T17:43:14.299Z'),
+          '00bef1e1-cb52-4914-8887-568b17d99964'
+        )
+      )
+    ).toMatchObject(
+      new MonthlyEventsView(
+        [
+          new EventView(
+            'eb9e1d9b-dce2-48a9-b64f-f0872f3157d2',
+            'mission',
+            0.75,
+            '2019-12-12',
+            'Summary',
+            new ProjectView(
+              'bf4a645c-9754-4943-baec-783361c6d814',
+              'RadioFrance'
+            ),
+            new TaskView('7fb77f06-2d0b-4758-886a-42bba5445fcd', 'Development')
+          ),
+          new EventView(
+            'b9a9b094-5bb2-4d0b-b01e-231b6cb50039',
+            'dojo',
+            0.25,
+            '2019-12-12',
+            null,
+            null,
+            null
+          ),
+          new EventView(
+            'a773a25d-8028-4190-bc03-51b33a0d1528',
+            'holiday',
+            1,
+            '2019-12-17',
+            null,
+            null,
+            null
+          )
+        ],
+        overview
+      )
+    );
+    verify(
+      dateUtils.format(
+        deepEqual(new Date(`2019-12-12T17:43:14.299Z`)),
+        'y-MM-dd'
+      )
+    ).once();
+
+    verify(
+      eventRepository.findMonthlyEvents(
+        '2019-12-12',
+        '00bef1e1-cb52-4914-8887-568b17d99964'
+      )
+    ).once();
+    verify(getEventsOverview.index(events)).once();
+  });
+});

--- a/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.spec.ts
@@ -60,7 +60,6 @@ describe('GetMonthlyEventsQueryHandler', () => {
       holiday: 1,
       medicalLeave: 0,
       support: 0,
-      workFree: 0,
       other: 0,
       mealTicket: 1,
       totalTimeSpent: 1

--- a/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler.ts
@@ -1,0 +1,53 @@
+import {Inject} from '@nestjs/common';
+import {QueryHandler} from '@nestjs/cqrs';
+import {GetMonthlyEventsQuery} from './GetMonthlyEventsQuery';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {EventView} from '../View/EventView';
+import {IDateUtils} from 'src/Application/IDateUtils';
+import {GetEventsOverview} from 'src/Domain/FairCalendar/GetEventsOverview';
+import {MonthlyEventsView} from '../View/MonthlyEventsView';
+import {ProjectView} from 'src/Application/Project/View/ProjectView';
+import {TaskView} from 'src/Application/Task/View/TaskView';
+
+@QueryHandler(GetMonthlyEventsQuery)
+export class GetMonthlyEventsQueryHandler {
+  constructor(
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository,
+    @Inject('IDateUtils')
+    private readonly dateUtils: IDateUtils,
+    private readonly getEventsOverview: GetEventsOverview
+  ) {}
+
+  public async execute(
+    query: GetMonthlyEventsQuery
+  ): Promise<MonthlyEventsView> {
+    const {date, userId} = query;
+    const eventViews: EventView[] = [];
+    const events = await this.eventRepository.findMonthlyEvents(
+      this.dateUtils.format(date, 'y-MM-dd'),
+      userId
+    );
+
+    const overview = this.getEventsOverview.index(events);
+
+    for (const event of events) {
+      const project = event.getProject();
+      const task = event.getTask();
+
+      eventViews.push(
+        new EventView(
+          event.getId(),
+          event.getType(),
+          event.getTime() / 100,
+          event.getDate(),
+          event.getSummary(),
+          project ? new ProjectView(project.getId(), project.getName()) : null,
+          task ? new TaskView(task.getId(), task.getName()) : null
+        )
+      );
+    }
+
+    return new MonthlyEventsView(eventViews, overview);
+  }
+}

--- a/server/src/Application/FairCalendar/View/EventView.ts
+++ b/server/src/Application/FairCalendar/View/EventView.ts
@@ -1,0 +1,14 @@
+import {ProjectView} from 'src/Application/Project/View/ProjectView';
+import {TaskView} from 'src/Application/Task/View/TaskView';
+
+export class EventView {
+  constructor(
+    public readonly id: string,
+    public readonly type: string,
+    public readonly time: number,
+    public readonly date: string,
+    public readonly summary?: string,
+    public readonly project?: ProjectView,
+    public readonly task?: TaskView
+  ) {}
+}

--- a/server/src/Application/FairCalendar/View/MonthlyEventsView.ts
+++ b/server/src/Application/FairCalendar/View/MonthlyEventsView.ts
@@ -1,0 +1,9 @@
+import {EventView} from './EventView';
+import {IEventsOverview} from 'src/Domain/FairCalendar/IEventsOverview';
+
+export class MonthlyEventsView {
+  constructor(
+    public readonly events: EventView[],
+    public readonly overview: IEventsOverview
+  ) {}
+}

--- a/server/src/Domain/FairCalendar/Event.entity.ts
+++ b/server/src/Domain/FairCalendar/Event.entity.ts
@@ -9,7 +9,6 @@ export enum EventType {
   DOJO = 'dojo',
   FORMATION_CONFERENCE = 'formationConference',
   HOLIDAY = 'holiday',
-  WORK_FREE = 'workFree',
   MEDICAL_LEAVE = 'medicalLeave',
   OTHER = 'other'
 }

--- a/server/src/Domain/FairCalendar/Event.entity.ts
+++ b/server/src/Domain/FairCalendar/Event.entity.ts
@@ -1,0 +1,115 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import {User} from '../User/User.entity';
+import {Task} from '../Task/Task.entity';
+import {Project} from '../Project/Project.entity';
+
+export enum EventType {
+  MISSION = 'mission',
+  SUPPORT = 'support',
+  DOJO = 'dojo',
+  FORMATION_CONFERENCE = 'formationConference',
+  HOLIDAY = 'holiday',
+  WORK_FREE = 'workFree',
+  MEDICAL_LEAVE = 'medicalLeave',
+  OTHER = 'other'
+}
+
+@Entity()
+export class Event {
+  // Times spent are stored in base 100
+  public static readonly MAXIMUM_TIMESPENT_PER_DAY: number = 100;
+  public static readonly WORKED_TYPES: string[] = [
+    EventType.MISSION,
+    EventType.SUPPORT,
+    EventType.DOJO,
+    EventType.FORMATION_CONFERENCE
+  ];
+
+  @PrimaryGeneratedColumn('uuid')
+  private id: string;
+
+  @Column('enum', {enum: EventType, nullable: false})
+  private type: EventType;
+
+  @Column({type: 'integer', nullable: false})
+  private time: number;
+
+  @Column({type: 'date', nullable: false})
+  private date: string;
+
+  @Column({type: 'varchar', nullable: true})
+  private summary: string;
+
+  @ManyToOne(type => Project, {nullable: true})
+  private project: Project;
+
+  @ManyToOne(type => Task, {nullable: true})
+  private task: Task;
+
+  @ManyToOne(type => User, {nullable: false})
+  private user: User;
+
+  constructor(
+    type: EventType,
+    user: User,
+    time: number,
+    date: string,
+    project?: Project,
+    task?: Task,
+    summary?: string
+  ) {
+    this.type = type;
+    this.user = user;
+    this.time = time;
+    this.date = date;
+    this.project = project;
+    this.task = task;
+    this.summary = summary;
+  }
+
+  public getId(): string {
+    return this.id;
+  }
+
+  public getType(): string {
+    return this.type;
+  }
+
+  public getTime(): number {
+    return this.time;
+  }
+
+  public getDate(): string {
+    return this.date;
+  }
+
+  public getSummary(): string | null {
+    return this.summary;
+  }
+
+  public getProject(): Project | null {
+    return this.project;
+  }
+
+  public getTask(): Task | null {
+    return this.task;
+  }
+
+  public getUser(): User {
+    return this.user;
+  }
+
+  public update(
+    type: EventType,
+    time: number,
+    project?: Project,
+    task?: Task,
+    summary?: string
+  ): void {
+    this.type = type;
+    this.time = time;
+    this.project = project;
+    this.task = task;
+    this.summary = summary;
+  }
+}

--- a/server/src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException.ts
+++ b/server/src/Domain/FairCalendar/Exception/EventDoesntBelongToUserException.ts
@@ -1,0 +1,5 @@
+export class EventDoesntBelongToUserException extends Error {
+  constructor() {
+    super('fair_calendar.errors.event_doesnt_belong_to_user');
+  }
+}

--- a/server/src/Domain/FairCalendar/Exception/EventNotFoundException.ts
+++ b/server/src/Domain/FairCalendar/Exception/EventNotFoundException.ts
@@ -1,0 +1,5 @@
+export class EventNotFoundException extends Error {
+  constructor() {
+    super('fair_calendar.errors.event_not_found');
+  }
+}

--- a/server/src/Domain/FairCalendar/Exception/MaximumEventReachedException.ts
+++ b/server/src/Domain/FairCalendar/Exception/MaximumEventReachedException.ts
@@ -1,0 +1,5 @@
+export class MaximumEventReachedException extends Error {
+  constructor() {
+    super('fair_calendar.errors.event_maximum_reached');
+  }
+}

--- a/server/src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException.ts
+++ b/server/src/Domain/FairCalendar/Exception/ProjectOrTaskMissingException.ts
@@ -1,0 +1,5 @@
+export class ProjectOrTaskMissingException extends Error {
+  constructor() {
+    super('fair_calendar.errors.project_or_task_missing');
+  }
+}

--- a/server/src/Domain/FairCalendar/GetEventsOverview.spec.ts
+++ b/server/src/Domain/FairCalendar/GetEventsOverview.spec.ts
@@ -1,0 +1,92 @@
+import {instance, mock, when, verify} from 'ts-mockito';
+import {GetEventsOverview} from './GetEventsOverview';
+import {Event, EventType} from './Event.entity';
+import {IEventsOverview} from './IEventsOverview';
+
+describe('GetEventsOverview', () => {
+  let getEventsOverview: GetEventsOverview;
+
+  beforeEach(() => {
+    getEventsOverview = new GetEventsOverview();
+  });
+
+  it('testGetOverview', async () => {
+    const event1 = mock(Event);
+    when(event1.getType()).thenReturn(EventType.MISSION);
+    when(event1.getTime()).thenReturn(75);
+    when(event1.getDate()).thenReturn('2019-12-12');
+
+    const event2 = mock(Event);
+    when(event2.getType()).thenReturn(EventType.DOJO);
+    when(event2.getTime()).thenReturn(25);
+    when(event2.getDate()).thenReturn('2019-12-12');
+
+    const event3 = mock(Event);
+    when(event3.getType()).thenReturn(EventType.HOLIDAY);
+    when(event3.getDate()).thenReturn('2019-12-17');
+    when(event3.getTime()).thenReturn(100);
+
+    const event4 = mock(Event);
+    when(event4.getType()).thenReturn(EventType.MISSION);
+    when(event4.getTime()).thenReturn(50);
+    when(event4.getDate()).thenReturn('2019-12-13');
+
+    const event5 = mock(Event);
+    when(event5.getType()).thenReturn(EventType.MISSION);
+    when(event5.getTime()).thenReturn(25);
+    when(event5.getDate()).thenReturn('2019-12-10');
+
+    const event6 = mock(Event);
+    when(event6.getType()).thenReturn(EventType.SUPPORT);
+    when(event6.getTime()).thenReturn(75);
+    when(event6.getDate()).thenReturn('2019-12-10');
+
+    const event7 = mock(Event);
+    when(event7.getType()).thenReturn(EventType.MEDICAL_LEAVE);
+    when(event7.getTime()).thenReturn(100);
+    when(event7.getDate()).thenReturn('2019-12-01');
+
+    const event8 = mock(Event);
+    when(event8.getType()).thenReturn(EventType.WORK_FREE);
+    when(event8.getTime()).thenReturn(100);
+    when(event8.getDate()).thenReturn('2019-12-02');
+
+    const event9 = mock(Event);
+    when(event9.getType()).thenReturn(EventType.FORMATION_CONFERENCE);
+    when(event9.getTime()).thenReturn(100);
+    when(event9.getDate()).thenReturn('2019-12-03');
+
+    const event10 = mock(Event);
+    when(event10.getType()).thenReturn(EventType.OTHER);
+    when(event10.getTime()).thenReturn(50);
+    when(event10.getDate()).thenReturn('2019-12-04');
+
+    const expectedResult: IEventsOverview = {
+      mission: 1.5,
+      dojo: 0.25,
+      formationConference: 1,
+      holiday: 1,
+      medicalLeave: 1,
+      support: 0.75,
+      workFree: 1,
+      other: 0.5,
+      mealTicket: 3,
+      totalTimeSpent: 3.5
+    };
+
+    expect(
+      await getEventsOverview.index([
+        instance(event1),
+        instance(event2),
+        instance(event3),
+        instance(event4),
+        instance(event5),
+        instance(event6),
+        instance(event7),
+        instance(event8),
+        instance(event9),
+        instance(event10)
+      ])
+    ).toMatchObject(expectedResult);
+  });
+});

--- a/server/src/Domain/FairCalendar/GetEventsOverview.spec.ts
+++ b/server/src/Domain/FairCalendar/GetEventsOverview.spec.ts
@@ -46,11 +46,6 @@ describe('GetEventsOverview', () => {
     when(event7.getTime()).thenReturn(100);
     when(event7.getDate()).thenReturn('2019-12-01');
 
-    const event8 = mock(Event);
-    when(event8.getType()).thenReturn(EventType.WORK_FREE);
-    when(event8.getTime()).thenReturn(100);
-    when(event8.getDate()).thenReturn('2019-12-02');
-
     const event9 = mock(Event);
     when(event9.getType()).thenReturn(EventType.FORMATION_CONFERENCE);
     when(event9.getTime()).thenReturn(100);
@@ -68,7 +63,6 @@ describe('GetEventsOverview', () => {
       holiday: 1,
       medicalLeave: 1,
       support: 0.75,
-      workFree: 1,
       other: 0.5,
       mealTicket: 3,
       totalTimeSpent: 3.5
@@ -83,7 +77,6 @@ describe('GetEventsOverview', () => {
         instance(event5),
         instance(event6),
         instance(event7),
-        instance(event8),
         instance(event9),
         instance(event10)
       ])

--- a/server/src/Domain/FairCalendar/GetEventsOverview.ts
+++ b/server/src/Domain/FairCalendar/GetEventsOverview.ts
@@ -11,7 +11,6 @@ export class GetEventsOverview {
       holiday: 0,
       medicalLeave: 0,
       support: 0,
-      workFree: 0,
       other: 0,
       mealTicket: 0,
       totalTimeSpent: 0

--- a/server/src/Domain/FairCalendar/GetEventsOverview.ts
+++ b/server/src/Domain/FairCalendar/GetEventsOverview.ts
@@ -1,0 +1,64 @@
+import {Event} from './Event.entity';
+import {IEventsOverview} from './IEventsOverview';
+
+export class GetEventsOverview {
+  public index(events: Event[]): IEventsOverview {
+    const eventsByDate = [];
+    const overview: IEventsOverview = {
+      mission: 0,
+      dojo: 0,
+      formationConference: 0,
+      holiday: 0,
+      medicalLeave: 0,
+      support: 0,
+      workFree: 0,
+      other: 0,
+      mealTicket: 0,
+      totalTimeSpent: 0
+    };
+
+    for (const event of events) {
+      const dayIndex = new Date(event.getDate()).getDate() - 1;
+      const time = event.getTime() / 100;
+      const type = event.getType();
+
+      if (eventsByDate[dayIndex]) {
+        eventsByDate[dayIndex].push({time, type});
+      } else {
+        eventsByDate[dayIndex] = [{time, type}];
+      }
+
+      overview[event.getType()] += time;
+
+      if (Event.WORKED_TYPES.includes(type)) {
+        overview.totalTimeSpent += time;
+      }
+    }
+
+    return this.calculateNumberOfMealTicket(
+      overview,
+      Object.values(eventsByDate)
+    );
+  }
+
+  public calculateNumberOfMealTicket(
+    overview: IEventsOverview,
+    eventsByDate: any[]
+  ): IEventsOverview {
+    for (const sortedEvent of eventsByDate) {
+      let totalPerDay = 0;
+
+      for (const {time, type} of sortedEvent) {
+        if (Event.WORKED_TYPES.includes(type)) {
+          totalPerDay += time;
+        }
+      }
+
+      if (totalPerDay > 0.5) {
+        overview.mealTicket++;
+      }
+    }
+
+    return overview;
+  }
+}

--- a/server/src/Domain/FairCalendar/IEventsOverview.ts
+++ b/server/src/Domain/FairCalendar/IEventsOverview.ts
@@ -5,7 +5,6 @@ export interface IEventsOverview {
   holiday: number;
   medicalLeave: number;
   support: number;
-  workFree: number;
   other: number;
   mealTicket: number;
   totalTimeSpent: number;

--- a/server/src/Domain/FairCalendar/IEventsOverview.ts
+++ b/server/src/Domain/FairCalendar/IEventsOverview.ts
@@ -1,0 +1,12 @@
+export interface IEventsOverview {
+  mission: number;
+  dojo: number;
+  formationConference: number;
+  holiday: number;
+  medicalLeave: number;
+  support: number;
+  workFree: number;
+  other: number;
+  mealTicket: number;
+  totalTimeSpent: number;
+}

--- a/server/src/Domain/FairCalendar/Repository/IEventRepository.ts
+++ b/server/src/Domain/FairCalendar/Repository/IEventRepository.ts
@@ -1,0 +1,10 @@
+import {Event} from '../Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+export interface IEventRepository {
+  save(activity: Event): Promise<Event>;
+  delete(event: Event): void;
+  findOneById(id: string): Promise<Event | undefined>;
+  findMonthlyEvents(date: string, userId: string): Promise<Event[]>;
+  getDayTimeSpentByUser(user: User, date: string): Promise<number>;
+}

--- a/server/src/Domain/FairCalendar/Specification/DoesEventBelongToUser.spec.ts
+++ b/server/src/Domain/FairCalendar/Specification/DoesEventBelongToUser.spec.ts
@@ -1,13 +1,13 @@
 import {instance, mock, when} from 'ts-mockito';
-import {IsEventBelongToUser} from './IsEventBelongToUser';
+import {DoesEventBelongToUser} from './DoesEventBelongToUser';
 import {Event} from '../Event.entity';
 import {User} from 'src/Domain/User/User.entity';
 
-describe('IsEventBelongToUser', () => {
-  let isEventBelongToUser: IsEventBelongToUser;
+describe('DoesEventBelongToUser', () => {
+  let doesEventBelongToUser: DoesEventBelongToUser;
 
   beforeEach(() => {
-    isEventBelongToUser = new IsEventBelongToUser();
+    doesEventBelongToUser = new DoesEventBelongToUser();
   });
 
   it('testEventNotBelongToUser', async () => {
@@ -20,7 +20,7 @@ describe('IsEventBelongToUser', () => {
     when(event.getUser()).thenReturn(instance(otherUser));
 
     expect(
-      await isEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
+      await doesEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
     ).toBe(false);
   });
 
@@ -32,7 +32,7 @@ describe('IsEventBelongToUser', () => {
     when(event.getUser()).thenReturn(instance(user));
 
     expect(
-      await isEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
+      await doesEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
     ).toBe(true);
   });
 });

--- a/server/src/Domain/FairCalendar/Specification/DoesEventBelongToUser.ts
+++ b/server/src/Domain/FairCalendar/Specification/DoesEventBelongToUser.ts
@@ -1,7 +1,7 @@
 import {Event} from '../Event.entity';
 import {User} from 'src/Domain/User/User.entity';
 
-export class IsEventBelongToUser {
+export class DoesEventBelongToUser {
   public isSatisfiedBy(event: Event, user: User): boolean {
     return event.getUser().getId() === user.getId();
   }

--- a/server/src/Domain/FairCalendar/Specification/IsEventBelongToUser.spec.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsEventBelongToUser.spec.ts
@@ -1,0 +1,38 @@
+import {instance, mock, when} from 'ts-mockito';
+import {IsEventBelongToUser} from './IsEventBelongToUser';
+import {Event} from '../Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+describe('IsEventBelongToUser', () => {
+  let isEventBelongToUser: IsEventBelongToUser;
+
+  beforeEach(() => {
+    isEventBelongToUser = new IsEventBelongToUser();
+  });
+
+  it('testEventNotBelongToUser', async () => {
+    const user = mock(User);
+    const otherUser = mock(User);
+    const event = mock(Event);
+
+    when(user.getId()).thenReturn('d8705a30-e626-4d99-b6a0-af0c239e5163');
+    when(otherUser.getId()).thenReturn('cadd8a80-63ba-4030-8a69-2aadd861630c');
+    when(event.getUser()).thenReturn(instance(otherUser));
+
+    expect(
+      await isEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
+    ).toBe(false);
+  });
+
+  it('testMaximumTimeSpentReached', async () => {
+    const user = mock(User);
+    const event = mock(Event);
+
+    when(user.getId()).thenReturn('d8705a30-e626-4d99-b6a0-af0c239e5163');
+    when(event.getUser()).thenReturn(instance(user));
+
+    expect(
+      await isEventBelongToUser.isSatisfiedBy(instance(event), instance(user))
+    ).toBe(true);
+  });
+});

--- a/server/src/Domain/FairCalendar/Specification/IsEventBelongToUser.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsEventBelongToUser.ts
@@ -1,0 +1,8 @@
+import {Event} from '../Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+export class IsEventBelongToUser {
+  public isSatisfiedBy(event: Event, user: User): boolean {
+    return event.getUser().getId() === user.getId();
+  }
+}

--- a/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached.spec.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached.spec.ts
@@ -1,0 +1,63 @@
+import {instance, mock, when, verify} from 'ts-mockito';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {IsMaximumTimeSpentReached} from './IsMaximumTimeSpentReached';
+import {Event} from '../Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+describe('IsMaximumTimeSpentReached', () => {
+  let eventRepository: EventRepository;
+  let isMaximumTimeSpentReached: IsMaximumTimeSpentReached;
+
+  beforeEach(() => {
+    eventRepository = mock(EventRepository);
+    isMaximumTimeSpentReached = new IsMaximumTimeSpentReached(
+      instance(eventRepository)
+    );
+  });
+
+  it('testMaximumTimeSpentNotReached', async () => {
+    const user = mock(User);
+    const event = mock(Event);
+
+    when(event.getUser()).thenReturn(instance(user));
+    when(event.getDate()).thenReturn('2019-01-01');
+    when(event.getTime()).thenReturn(50);
+    when(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).thenResolve(50);
+
+    expect(await isMaximumTimeSpentReached.isSatisfiedBy(instance(event))).toBe(
+      false
+    );
+
+    verify(event.getUser()).once();
+    verify(event.getDate()).once();
+    verify(event.getTime()).once();
+    verify(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).once();
+  });
+
+  it('testMaximumTimeSpentReached', async () => {
+    const user = mock(User);
+    const event = mock(Event);
+
+    when(event.getUser()).thenReturn(instance(user));
+    when(event.getDate()).thenReturn('2019-01-01');
+    when(event.getTime()).thenReturn(50);
+    when(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).thenResolve(75);
+
+    expect(await isMaximumTimeSpentReached.isSatisfiedBy(instance(event))).toBe(
+      true
+    );
+
+    verify(event.getUser()).once();
+    verify(event.getDate()).once();
+    verify(event.getTime()).once();
+    verify(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).once();
+  });
+});

--- a/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached.ts
@@ -1,0 +1,20 @@
+import {Inject} from '@nestjs/common';
+import {ISpecification} from 'src/Domain/ISpecification';
+import {IEventRepository} from '../Repository/IEventRepository';
+import {Event} from '../Event.entity';
+
+export class IsMaximumTimeSpentReached implements ISpecification {
+  constructor(
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository
+  ) {}
+
+  public async isSatisfiedBy(event: Event): Promise<boolean> {
+    const timeSpent = await this.eventRepository.getDayTimeSpentByUser(
+      event.getUser(),
+      event.getDate()
+    );
+
+    return timeSpent + event.getTime() > Event.MAXIMUM_TIMESPENT_PER_DAY;
+  }
+}

--- a/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition.spec.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition.spec.ts
@@ -1,0 +1,69 @@
+import {instance, mock, when, verify} from 'ts-mockito';
+import {EventRepository} from 'src/Infrastructure/FairCalendar/Repository/EventRepository';
+import {IsMaximumTimeSpentReachedOnEdition} from './IsMaximumTimeSpentReachedOnEdition';
+import {Event} from '../Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+describe('IsMaximumTimeSpentReachedOnEdition', () => {
+  let eventRepository: EventRepository;
+  let isMaximumTimeSpentReachedOnEdition: IsMaximumTimeSpentReachedOnEdition;
+
+  beforeEach(() => {
+    eventRepository = mock(EventRepository);
+    isMaximumTimeSpentReachedOnEdition = new IsMaximumTimeSpentReachedOnEdition(
+      instance(eventRepository)
+    );
+  });
+
+  it('testMaximumTimeSpentNotReached', async () => {
+    const user = mock(User);
+    const event = mock(Event);
+
+    when(event.getUser()).thenReturn(instance(user));
+    when(event.getDate()).thenReturn('2019-01-01');
+    when(event.getTime()).thenReturn(50);
+    when(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).thenResolve(100);
+
+    expect(
+      await isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(
+        instance(event),
+        50
+      )
+    ).toBe(false);
+
+    verify(event.getUser()).once();
+    verify(event.getDate()).once();
+    verify(event.getTime()).once();
+    verify(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).once();
+  });
+
+  it('testMaximumTimeSpentReached', async () => {
+    const user = mock(User);
+    const event = mock(Event);
+
+    when(event.getUser()).thenReturn(instance(user));
+    when(event.getDate()).thenReturn('2019-01-01');
+    when(event.getTime()).thenReturn(50);
+    when(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).thenResolve(75);
+
+    expect(
+      await isMaximumTimeSpentReachedOnEdition.isSatisfiedBy(
+        instance(event),
+        100
+      )
+    ).toBe(true);
+
+    verify(event.getUser()).once();
+    verify(event.getDate()).once();
+    verify(event.getTime()).once();
+    verify(
+      eventRepository.getDayTimeSpentByUser(instance(user), '2019-01-01')
+    ).once();
+  });
+});

--- a/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition.ts
+++ b/server/src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition.ts
@@ -1,0 +1,21 @@
+import {Inject} from '@nestjs/common';
+import {IEventRepository} from '../Repository/IEventRepository';
+import {Event} from '../Event.entity';
+
+export class IsMaximumTimeSpentReachedOnEdition {
+  constructor(
+    @Inject('IEventRepository')
+    private readonly eventRepository: IEventRepository
+  ) {}
+
+  public async isSatisfiedBy(event: Event, newTime: number): Promise<boolean> {
+    const timeSpent = await this.eventRepository.getDayTimeSpentByUser(
+      event.getUser(),
+      event.getDate()
+    );
+
+    return (
+      timeSpent - event.getTime() + newTime > Event.MAXIMUM_TIMESPENT_PER_DAY
+    );
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/AddEventAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/AddEventAction.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Post,
+  Controller,
+  Inject,
+  BadRequestException,
+  UseGuards
+} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiUseTags, ApiBearerAuth, ApiOperation} from '@nestjs/swagger';
+import {ICommandBus} from 'src/Application/ICommandBus';
+import {LoggedUser} from 'src/Infrastructure/User/Decorator/LoggedUser';
+import {User} from 'src/Domain/User/User.entity';
+import {AddEventCommand} from 'src/Application/FairCalendar/Command/AddEventCommand';
+import {EventDTO} from './DTO/EventDTO';
+
+@Controller('events')
+@ApiUseTags('Event')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'))
+export class AddEventAction {
+  constructor(
+    @Inject('ICommandBus')
+    private readonly commandBus: ICommandBus
+  ) {}
+
+  @Post()
+  @ApiOperation({title: 'Add new event'})
+  public async index(@Body() dto: EventDTO, @LoggedUser() user: User) {
+    try {
+      const {type, date, projectId, taskId, summary, time} = dto;
+      const id = await this.commandBus.execute(
+        new AddEventCommand(
+          type,
+          user,
+          Number(time),
+          new Date(date),
+          projectId,
+          taskId,
+          summary
+        )
+      );
+
+      return {id};
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/EventDTO.spec.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/EventDTO.spec.ts
@@ -1,0 +1,64 @@
+import {EventDTO} from './EventDTO';
+import {validate} from 'class-validator';
+import {EventType} from 'src/Domain/FairCalendar/Event.entity';
+
+describe('EventDTO', () => {
+  it('testValidDTO', async () => {
+    const dto = new EventDTO();
+    dto.type = EventType.MISSION;
+    dto.date = '2019-12-19T11:20:04.568Z';
+    dto.time = '25';
+    dto.projectId = '2218609f-293b-4438-b3a0-cce8961e8acc';
+    dto.taskId = 'ff623892-434b-4f2d-945e-775c87bae2ac';
+    dto.summary = 'Summary';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(0);
+  });
+
+  it('testInvalidDTO', async () => {
+    const dto = new EventDTO();
+    dto.date = '2019-12-19';
+    dto.time = '30';
+    dto.projectId = '1';
+    dto.taskId = '2';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(5);
+    expect(validation[0].constraints).toMatchObject({
+      isEnum: 'type must be a valid enum value',
+      isNotEmpty: 'type should not be empty'
+    });
+    expect(validation[1].constraints).toMatchObject({
+      isDateString: 'date must be a ISOString'
+    });
+    expect(validation[2].constraints).toMatchObject({
+      isIn: 'time must be one of the following values: 25,50,75,100'
+    });
+    expect(validation[3].constraints).toMatchObject({
+      isUuid: 'projectId must be an UUID'
+    });
+    expect(validation[4].constraints).toMatchObject({
+      isUuid: 'taskId must be an UUID'
+    });
+  });
+
+  it('testEmptyDTO', async () => {
+    const dto = new EventDTO();
+    dto.date = '';
+    dto.time = '';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(3);
+    expect(validation[0].constraints).toMatchObject({
+      isEnum: 'type must be a valid enum value',
+      isNotEmpty: 'type should not be empty'
+    });
+    expect(validation[1].constraints).toMatchObject({
+      isNotEmpty: 'date should not be empty'
+    });
+    expect(validation[2].constraints).toMatchObject({
+      isNotEmpty: 'time should not be empty'
+    });
+  });
+});

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/EventDTO.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/EventDTO.ts
@@ -1,0 +1,45 @@
+import {ApiModelProperty, ApiModelPropertyOptional} from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsUUID,
+  IsDateString,
+  IsString,
+  IsIn,
+  IsNumberString,
+  IsEnum,
+  IsOptional
+} from 'class-validator';
+import {EventType} from 'src/Domain/FairCalendar/Event.entity';
+
+export class EventDTO {
+  @ApiModelProperty({enum: EventType})
+  @IsNotEmpty()
+  @IsEnum(EventType)
+  public type: EventType;
+
+  @ApiModelProperty()
+  @IsNotEmpty()
+  @IsDateString()
+  public date: string;
+
+  @ApiModelProperty()
+  @IsNotEmpty()
+  @IsNumberString()
+  @IsIn(['25', '50', '75', '100'])
+  public time: string;
+
+  @ApiModelPropertyOptional()
+  @IsOptional()
+  @IsUUID()
+  public projectId?: string;
+
+  @ApiModelPropertyOptional()
+  @IsOptional()
+  @IsUUID()
+  public taskId?: string;
+
+  @ApiModelPropertyOptional()
+  @IsOptional()
+  @IsString()
+  public summary?: string;
+}

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/EventIdDTO.spec.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/EventIdDTO.spec.ts
@@ -1,0 +1,33 @@
+import {EventIdDTO} from './EventIdDTO';
+import {validate} from 'class-validator';
+
+describe('EventIdDTO', () => {
+  it('testValidDTO', async () => {
+    const dto = new EventIdDTO();
+    dto.id = 'ff623892-434b-4f2d-945e-775c87bae2ac';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(0);
+  });
+
+  it('testInvalidDTO', async () => {
+    const dto = new EventIdDTO();
+    dto.id = '25';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(1);
+    expect(validation[0].constraints).toMatchObject({
+      isUuid: 'id must be an UUID'
+    });
+  });
+
+  it('testEmptyDTO', async () => {
+    const dto = new EventIdDTO();
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(1);
+    expect(validation[0].constraints).toMatchObject({
+      isNotEmpty: 'id should not be empty'
+    });
+  });
+});

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/EventIdDTO.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/EventIdDTO.ts
@@ -1,0 +1,9 @@
+import {ApiModelProperty} from '@nestjs/swagger';
+import {IsNotEmpty, IsUUID} from 'class-validator';
+
+export class EventIdDTO {
+  @ApiModelProperty()
+  @IsNotEmpty()
+  @IsUUID()
+  public id: string;
+}

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/MonthlyEventsDTO.spec.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/MonthlyEventsDTO.spec.ts
@@ -1,0 +1,43 @@
+import {validate} from 'class-validator';
+import {MonthlyEventsDTO} from './MonthlyEventsDTO';
+
+describe('MonthlyEventsDTO', () => {
+  it('testValidDTO', async () => {
+    const dto = new MonthlyEventsDTO();
+    dto.date = '2019-12-19T11:20:04.568Z';
+    dto.userId = '2218609f-293b-4438-b3a0-cce8961e8acc';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(0);
+  });
+
+  it('testInvalidDTO', async () => {
+    const dto = new MonthlyEventsDTO();
+    dto.date = '2019-12-19';
+    dto.userId = '1';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(2);
+    expect(validation[0].constraints).toMatchObject({
+      isUuid: 'userId must be an UUID'
+    });
+    expect(validation[1].constraints).toMatchObject({
+      isDateString: 'date must be a ISOString'
+    });
+  });
+
+  it('testEmptyDTO', async () => {
+    const dto = new MonthlyEventsDTO();
+    dto.date = '';
+    dto.userId = '';
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(2);
+    expect(validation[0].constraints).toMatchObject({
+      isNotEmpty: 'userId should not be empty'
+    });
+    expect(validation[1].constraints).toMatchObject({
+      isNotEmpty: 'date should not be empty'
+    });
+  });
+});

--- a/server/src/Infrastructure/FairCalendar/Action/DTO/MonthlyEventsDTO.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DTO/MonthlyEventsDTO.ts
@@ -1,0 +1,14 @@
+import {ApiModelProperty} from '@nestjs/swagger';
+import {IsNotEmpty, IsUUID, IsDateString} from 'class-validator';
+
+export class MonthlyEventsDTO {
+  @ApiModelProperty()
+  @IsNotEmpty()
+  @IsUUID()
+  public userId: string;
+
+  @ApiModelProperty()
+  @IsNotEmpty()
+  @IsDateString()
+  public date: string;
+}

--- a/server/src/Infrastructure/FairCalendar/Action/DeleteEventAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/DeleteEventAction.ts
@@ -1,0 +1,38 @@
+import {
+  Delete,
+  Controller,
+  Inject,
+  BadRequestException,
+  UseGuards,
+  Param,
+  HttpCode
+} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiUseTags, ApiBearerAuth, ApiOperation} from '@nestjs/swagger';
+import {ICommandBus} from 'src/Application/ICommandBus';
+import {LoggedUser} from 'src/Infrastructure/User/Decorator/LoggedUser';
+import {User} from 'src/Domain/User/User.entity';
+import {DeleteEventCommand} from 'src/Application/FairCalendar/Command/DeleteEventCommand';
+import {EventIdDTO} from './DTO/EventIdDTO';
+
+@Controller('events')
+@ApiUseTags('Event')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'))
+export class DeleteEventAction {
+  constructor(
+    @Inject('ICommandBus')
+    private readonly commandBus: ICommandBus
+  ) {}
+
+  @Delete(':id')
+  @ApiOperation({title: 'Delete an event'})
+  @HttpCode(204)
+  public async index(@Param() dto: EventIdDTO, @LoggedUser() user: User) {
+    try {
+      await this.commandBus.execute(new DeleteEventCommand(dto.id, user));
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/GetEventAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/GetEventAction.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Inject,
+  BadRequestException,
+  UseGuards,
+  Param,
+  Get
+} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiUseTags, ApiBearerAuth, ApiOperation} from '@nestjs/swagger';
+import {IQueryBus} from 'src/Application/IQueryBus';
+import {EventIdDTO} from './DTO/EventIdDTO';
+import {GetEventByIdQuery} from 'src/Application/FairCalendar/Query/GetEventByIdQuery';
+import {EventView} from 'src/Application/FairCalendar/View/EventView';
+
+@Controller('events')
+@ApiUseTags('Event')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'))
+export class GetEventAction {
+  constructor(
+    @Inject('IQueryBus')
+    private readonly queryBus: IQueryBus
+  ) {}
+
+  @Get(':id')
+  @ApiOperation({title: 'Get event'})
+  public async index(@Param() dto: EventIdDTO): Promise<EventView> {
+    try {
+      return await this.queryBus.execute(new GetEventByIdQuery(dto.id));
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/GetMonthlyEventsAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/GetMonthlyEventsAction.ts
@@ -1,0 +1,25 @@
+import {Controller, Inject, UseGuards, Query, Get} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiUseTags, ApiBearerAuth, ApiOperation} from '@nestjs/swagger';
+import {IQueryBus} from 'src/Application/IQueryBus';
+import {GetMonthlyEventsQuery} from 'src/Application/FairCalendar/Query/GetMonthlyEventsQuery';
+import {MonthlyEventsDTO} from './DTO/MonthlyEventsDTO';
+
+@Controller('events')
+@ApiUseTags('Event')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'))
+export class GetMonthlyActivitiesAction {
+  constructor(
+    @Inject('IQueryBus')
+    private readonly queryBus: IQueryBus
+  ) {}
+
+  @Get()
+  @ApiOperation({title: 'Get monthly events by user'})
+  public async index(@Query() dto: MonthlyEventsDTO) {
+    return await this.queryBus.execute(
+      new GetMonthlyEventsQuery(new Date(dto.date), dto.userId)
+    );
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/UpdateEventAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/UpdateEventAction.ts
@@ -1,0 +1,56 @@
+import {
+  Controller,
+  Inject,
+  BadRequestException,
+  UseGuards,
+  Param,
+  Put,
+  Body
+} from '@nestjs/common';
+import {AuthGuard} from '@nestjs/passport';
+import {ApiUseTags, ApiBearerAuth, ApiOperation} from '@nestjs/swagger';
+import {EventIdDTO} from './DTO/EventIdDTO';
+import {LoggedUser} from 'src/Infrastructure/User/Decorator/LoggedUser';
+import {User} from 'src/Domain/User/User.entity';
+import {EventDTO} from './DTO/EventDTO';
+import {ICommandBus} from 'src/Application/ICommandBus';
+import {UpdateEventCommand} from 'src/Application/FairCalendar/Command/UpdateEventCommand';
+
+@Controller('events')
+@ApiUseTags('Event')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'))
+export class UpdateEventAction {
+  constructor(
+    @Inject('ICommandBus')
+    private readonly commandBus: ICommandBus
+  ) {}
+
+  @Put(':id')
+  @ApiOperation({title: 'Update event'})
+  public async index(
+    @Param() idDto: EventIdDTO,
+    @Body() dto: EventDTO,
+    @LoggedUser() user: User
+  ) {
+    const {type, time, summary, projectId, taskId} = dto;
+
+    try {
+      const {id} = await this.commandBus.execute(
+        new UpdateEventCommand(
+          idDto.id,
+          user,
+          type,
+          Number(time),
+          projectId,
+          taskId,
+          summary
+        )
+      );
+
+      return {id};
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/Action/UpdateEventAction.ts
+++ b/server/src/Infrastructure/FairCalendar/Action/UpdateEventAction.ts
@@ -36,7 +36,7 @@ export class UpdateEventAction {
     const {type, time, summary, projectId, taskId} = dto;
 
     try {
-      const {id} = await this.commandBus.execute(
+      const id = await this.commandBus.execute(
         new UpdateEventCommand(
           idDto.id,
           user,

--- a/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
+++ b/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
@@ -17,7 +17,7 @@ export class EventRepository implements IEventRepository {
   }
 
   public delete(event: Event): void {
-    this.repository.delete(event);
+    this.repository.delete(event.getId());
   }
 
   public async getDayTimeSpentByUser(
@@ -43,6 +43,7 @@ export class EventRepository implements IEventRepository {
         'event.summary',
         'event.date',
         'event.type',
+        'user.id',
         'project.id',
         'project.name',
         'task.id',

--- a/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
+++ b/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
@@ -1,0 +1,99 @@
+import {Injectable} from '@nestjs/common';
+import {InjectRepository} from '@nestjs/typeorm';
+import {Repository} from 'typeorm';
+import {IEventRepository} from 'src/Domain/FairCalendar/Repository/IEventRepository';
+import {Event} from 'src/Domain/FairCalendar/Event.entity';
+import {User} from 'src/Domain/User/User.entity';
+
+@Injectable()
+export class EventRepository implements IEventRepository {
+  constructor(
+    @InjectRepository(Event)
+    private readonly repository: Repository<Event>
+  ) {}
+
+  public save(event: Event): Promise<Event> {
+    return this.repository.save(event);
+  }
+
+  public delete(event: Event): void {
+    this.repository.delete(event);
+  }
+
+  public async getDayTimeSpentByUser(
+    user: User,
+    date: string
+  ): Promise<number> {
+    const result = await this.repository
+      .createQueryBuilder('event')
+      .select('SUM(event.time) as time')
+      .where('event.date = :date', {date})
+      .andWhere('event.user = :user', {user: user.getId()})
+      .getRawOne();
+
+    return Number(result.time) || 0;
+  }
+
+  public findOneById(id: string): Promise<Event> {
+    return this.repository
+      .createQueryBuilder('event')
+      .select([
+        'event.id',
+        'event.time',
+        'event.summary',
+        'event.date',
+        'event.type',
+        'project.id',
+        'project.name',
+        'task.id',
+        'task.name'
+      ])
+      .where('event.id = :id', {id})
+      .innerJoin('event.user', 'user')
+      .leftJoin('event.project', 'project')
+      .leftJoin('event.task', 'task')
+      .getOne();
+  }
+
+  public findMonthlyEvents(date: string, userId: string): Promise<Event[]> {
+    const month = new Date(date).getMonth() + 1;
+    const year = new Date(date).getFullYear();
+
+    return this.repository
+      .createQueryBuilder('event')
+      .select([
+        'event.id',
+        'event.time',
+        'event.summary',
+        'event.date',
+        'event.type',
+        'project.id',
+        'project.name',
+        'task.id',
+        'task.name'
+      ])
+      .where('user.id = :userId', {userId})
+      .andWhere('extract(month FROM event.date) = :month', {month})
+      .andWhere('extract(year FROM event.date) = :year', {year})
+      .innerJoin('event.user', 'user')
+      .leftJoin('event.project', 'project')
+      .leftJoin('event.task', 'task')
+      .orderBy('event.date', 'ASC')
+      .getMany();
+  }
+
+  public findMonthlyOverview(date: string, userId: string): Promise<Event[]> {
+    const month = new Date(date).getMonth() + 1;
+    const year = new Date(date).getFullYear();
+
+    return this.repository
+      .createQueryBuilder('event')
+      .select(['event.time', 'event.date', 'event.type'])
+      .where('user.id = :userId', {userId})
+      .andWhere('extract(month FROM event.date) = :month', {month})
+      .andWhere('extract(year FROM event.date) = :year', {year})
+      .innerJoin('event.user', 'user')
+      .orderBy('event.date', 'ASC')
+      .getMany();
+  }
+}

--- a/server/src/Infrastructure/FairCalendar/faircalendar.module.ts
+++ b/server/src/Infrastructure/FairCalendar/faircalendar.module.ts
@@ -1,0 +1,51 @@
+import {Module} from '@nestjs/common';
+import {TypeOrmModule} from '@nestjs/typeorm';
+import {BusModule} from '../bus.module';
+import {EventRepository} from './Repository/EventRepository';
+import {Event} from 'src/Domain/FairCalendar/Event.entity';
+import {IsMaximumTimeSpentReached} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReached';
+import {AddEventAction} from './Action/AddEventAction';
+import {AddEventCommandHandler} from 'src/Application/FairCalendar/Command/AddEventCommandHandler';
+import {DeleteEventAction} from './Action/DeleteEventAction';
+import {DeleteEventCommandHandler} from 'src/Application/FairCalendar/Command/DeleteEventCommandHandler';
+import {TaskRepository} from '../Task/Repository/TaskRepository';
+import {Task} from 'src/Domain/Task/Task.entity';
+import {Project} from 'src/Domain/Project/Project.entity';
+import {ProjectRepository} from '../Project/Repository/ProjectRepository';
+import {GetMonthlyActivitiesAction} from './Action/GetMonthlyEventsAction';
+import {DateUtilsAdapter} from '../Adapter/DateUtilsAdapter';
+import {GetEventsOverview} from 'src/Domain/FairCalendar/GetEventsOverview';
+import {GetMonthlyEventsQueryHandler} from 'src/Application/FairCalendar/Query/GetMonthlyEventsQueryHandler';
+import {GetEventByIdQueryHandler} from 'src/Application/FairCalendar/Query/GetEventByIdQueryHandler';
+import {GetEventAction} from './Action/GetEventAction';
+import {UpdateEventAction} from './Action/UpdateEventAction';
+import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {UpdateEventCommandHandler} from 'src/Application/FairCalendar/Command/UpdateEventCommandHandler';
+import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
+
+@Module({
+  imports: [BusModule, TypeOrmModule.forFeature([Project, Event, Task])],
+  controllers: [
+    AddEventAction,
+    DeleteEventAction,
+    GetEventAction,
+    UpdateEventAction,
+    GetMonthlyActivitiesAction
+  ],
+  providers: [
+    {provide: 'IProjectRepository', useClass: ProjectRepository},
+    {provide: 'IEventRepository', useClass: EventRepository},
+    {provide: 'ITaskRepository', useClass: TaskRepository},
+    {provide: 'IDateUtils', useClass: DateUtilsAdapter},
+    IsMaximumTimeSpentReached,
+    AddEventCommandHandler,
+    GetMonthlyEventsQueryHandler,
+    DeleteEventCommandHandler,
+    UpdateEventCommandHandler,
+    GetEventByIdQueryHandler,
+    IsEventBelongToUser,
+    IsMaximumTimeSpentReachedOnEdition,
+    GetEventsOverview
+  ]
+})
+export class FairCalendarModule {}

--- a/server/src/Infrastructure/FairCalendar/faircalendar.module.ts
+++ b/server/src/Infrastructure/FairCalendar/faircalendar.module.ts
@@ -19,7 +19,7 @@ import {GetMonthlyEventsQueryHandler} from 'src/Application/FairCalendar/Query/G
 import {GetEventByIdQueryHandler} from 'src/Application/FairCalendar/Query/GetEventByIdQueryHandler';
 import {GetEventAction} from './Action/GetEventAction';
 import {UpdateEventAction} from './Action/UpdateEventAction';
-import {IsEventBelongToUser} from 'src/Domain/FairCalendar/Specification/IsEventBelongToUser';
+import {DoesEventBelongToUser} from 'src/Domain/FairCalendar/Specification/DoesEventBelongToUser';
 import {UpdateEventCommandHandler} from 'src/Application/FairCalendar/Command/UpdateEventCommandHandler';
 import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specification/IsMaximumTimeSpentReachedOnEdition';
 
@@ -43,7 +43,7 @@ import {IsMaximumTimeSpentReachedOnEdition} from 'src/Domain/FairCalendar/Specif
     DeleteEventCommandHandler,
     UpdateEventCommandHandler,
     GetEventByIdQueryHandler,
-    IsEventBelongToUser,
+    DoesEventBelongToUser,
     IsMaximumTimeSpentReachedOnEdition,
     GetEventsOverview
   ]

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,6 +7,7 @@ import {CustomerModule} from './Infrastructure/Customer/customer.module';
 import {TaskModule} from './Infrastructure/Task/task.module';
 import {ActivityModule} from './Infrastructure/Activity/activity.module';
 import {BillingModule} from './Infrastructure/Billing/billing.module';
+import {FairCalendarModule} from './Infrastructure/FairCalendar/faircalendar.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import {BillingModule} from './Infrastructure/Billing/billing.module';
     ActivityModule,
     BillingModule,
     CustomerModule,
+    FairCalendarModule,
     ProjectModule,
     TaskModule,
     UserModule


### PR DESCRIPTION
Cette PR a pour but de reproduire ce qui a été fait sur le FairCalendar qui remplacera ce qui a été fait sur la partie CRA.

Ca ressemble ressemble beaucoup à ce qui avait été développé à la différence que maintenant on doit saisir le type (dojo, mission, support, maladie etc.). Ca nous permet également de calculer automatiquement nos TR et d'avoir une vue synthétique de ce qu'on a pu faire durant le mois.
La majorité du code de cette PR est de la duplication de code `Activity` renommé en `Event`. La différence ce situe majoritairement au niveau de `GetMonthlyEventsQueryHandler` où les datas sont formalisés différemment (pour avoir un affichage en mode calendrier côté front) avec le rajout du calcul des TR.

![image](https://user-images.githubusercontent.com/2683379/79692523-eac04b80-8265-11ea-9963-de4553557417.png)
![image](https://user-images.githubusercontent.com/2683379/79691906-602a1d00-8262-11ea-8b28-86d17f6e4b9b.png)