### PR TITLE
display event summary in faircalendar as tooltip

### DIFF
--- a/client/i18n/fr.json
+++ b/client/i18n/fr.json
@@ -314,7 +314,7 @@
           "cdd": "CDD",
           "ctt": "CTT",
           "professionalization": "Contrat de professionalisation",
-          "apprenticeship": "Contrat de d'apprentisage"
+          "apprenticeship": "Contrat d'apprentisage"
         },
         "executive_position": "Statut cadre",
         "health_insurance": "Mutuelle",

--- a/client/src/routes/faircalendar/index.svelte
+++ b/client/src/routes/faircalendar/index.svelte
@@ -84,6 +84,7 @@
         }
 
         data.title = title;
+        data.summary = summary;
         if (isLoggedUser && id) {
           data.id = id;
           data.url = `faircalendar/${id}/edit`;
@@ -92,6 +93,11 @@
           $settings.theme === 'theme-dark'
             ? `event-${eventType}--dark`
             : `event-${eventType}`;
+      },
+      eventRender: (info) => {
+        if (info.event.extendedProps.summary) {
+          info.el.title = info.event.extendedProps.summary;
+        }
       },
       businessHours: {
         daysOfWeek: [1, 2, 3, 4, 5],

--- a/server/src/Application/FairCalendar/Query/GetMonthlyFairCalendarQueryHandler.spec.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyFairCalendarQueryHandler.spec.ts
@@ -32,6 +32,7 @@ describe('GetMonthlyFairCalendarQueryHandler', () => {
     when(event1.isBillable()).thenReturn(true);
     when(event1.getTime()).thenReturn(90);
     when(event1.getDate()).thenReturn('2019-12-12');
+    when(event1.getSummary()).thenReturn('lorem ipsum');
     when(event1.getTask()).thenReturn(instance(task));
     when(event1.getProject()).thenReturn(instance(project));
 
@@ -41,6 +42,7 @@ describe('GetMonthlyFairCalendarQueryHandler', () => {
     when(event2.getTime()).thenReturn(300);
     when(event2.isBillable()).thenReturn(false);
     when(event2.getDate()).thenReturn('2019-12-12');
+    when(event2.getSummary()).thenReturn('dolor sit amet');
     when(event2.getTask()).thenReturn(null);
     when(event2.getProject()).thenReturn(null);
 
@@ -95,6 +97,7 @@ describe('GetMonthlyFairCalendarQueryHandler', () => {
           'mission',
           90,
           '2019-12-12',
+          'lorem ipsum',
           'eb9e1d9b-dce2-48a9-b64f-f0872f3157d2',
           true,
           new ProjectView(
@@ -108,6 +111,7 @@ describe('GetMonthlyFairCalendarQueryHandler', () => {
           'dojo',
           300,
           '2019-12-12',
+          'dolor sit amet',
           'b9a9b094-5bb2-4d0b-b01e-231b6cb50039',
           false,
           null,

--- a/server/src/Application/FairCalendar/Query/GetMonthlyFairCalendarQueryHandler.ts
+++ b/server/src/Application/FairCalendar/Query/GetMonthlyFairCalendarQueryHandler.ts
@@ -50,6 +50,7 @@ export class GetMonthlyFairCalendarQueryHandler {
           event.getType(),
           event.getTime(),
           event.getDate(),
+          event.getSummary(),
           event.getId(),
           event.isBillable(),
           project ? new ProjectView(project.getId(), project.getName(), project.getDayDuration()) : null,

--- a/server/src/Application/FairCalendar/View/FairCalendarView.ts
+++ b/server/src/Application/FairCalendar/View/FairCalendarView.ts
@@ -6,6 +6,7 @@ export class FairCalendarView {
     public readonly type: string,
     public readonly time: number,
     public readonly date: string,
+    public readonly summary?: string,
     public readonly id?: string,
     public readonly billable?: boolean,
     public readonly project?: ProjectView,

--- a/server/src/Domain/FairCalendar/GetFaircalendarOverview.spec.ts
+++ b/server/src/Domain/FairCalendar/GetFaircalendarOverview.spec.ts
@@ -23,7 +23,7 @@ describe('GetFairCalendarOverview', () => {
     when(cooperativeRepository.find()).thenResolve(null);
 
     const project = new ProjectView('bd86391b-4ee2-45db-9fc0-66078845a8b6', 'RadioFrance', 420);
-    const event1 = new FairCalendarView(EventType.MISSION, 300, '2019-12-12', null, true, project);
+    const event1 = new FairCalendarView(EventType.MISSION, 300, '2019-12-12', null, null, true, project);
 
     try {
       await getFairCalendarOverview.index([event1]);
@@ -40,10 +40,10 @@ describe('GetFairCalendarOverview', () => {
 
     const project = new ProjectView('bd86391b-4ee2-45db-9fc0-66078845a8b6', 'RadioFrance', 420);
 
-    const event1 = new FairCalendarView(EventType.MISSION, 300, '2019-12-12', null, true, project);
+    const event1 = new FairCalendarView(EventType.MISSION, 300, '2019-12-12', null, null, true, project);
     const event2 = new FairCalendarView(EventType.DOJO, 120, '2019-12-12');
-    const event3 = new FairCalendarView(EventType.MISSION, 210, '2019-12-13', null, true, project);
-    const event5 = new FairCalendarView(EventType.MISSION, 240, '2019-12-10', null, true, project);
+    const event3 = new FairCalendarView(EventType.MISSION, 210, '2019-12-13', null, null, true, project);
+    const event5 = new FairCalendarView(EventType.MISSION, 240, '2019-12-10', null, null, true, project);
     const event6 = new FairCalendarView(EventType.SUPPORT, 240, '2019-12-10');
     const event7 = new FairCalendarView(EventType.FORMATION_CONFERENCE, 480, '2019-12-03');
     const event8 = new FairCalendarView(EventType.OTHER, 240, '2019-12-04');

--- a/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
+++ b/server/src/Infrastructure/FairCalendar/Repository/EventRepository.ts
@@ -71,6 +71,7 @@ export class EventRepository implements IEventRepository {
         'event.id',
         'event.time',
         'event.date',
+        'event.summary',
         'event.billable',
         'event.type',
         'project.id',


### PR DESCRIPTION
Actuellement, il faut ouvrir un evenement dans le faircalendar pour consulter la description, ce serait bien de l'avoir en tooltip directement à partir du calendrier

https://user-images.githubusercontent.com/1699735/103156419-ab5cde00-47a8-11eb-91d5-90df3a349eec.mov

