### PR TITLE
Add await when saving data to be sure db is up to date when client will refresh ui

### DIFF
--- a/server/src/Application/FairCalendar/Command/AddEventCommandHandler.ts
+++ b/server/src/Application/FairCalendar/Command/AddEventCommandHandler.ts
@@ -41,6 +41,8 @@ export class AddEventCommandHandler extends AbstractProjectAndTaskGetter {
       this.getTask(taskId)
     ]);
 
+    const savePromises: Promise<any>[] = [];
+
     for (const day of days) {
       const date = this.dateUtils.format(day, 'y-MM-dd');
       const event = new Event(
@@ -63,8 +65,10 @@ export class AddEventCommandHandler extends AbstractProjectAndTaskGetter {
         continue;
       }
 
-      this.eventRepository.save(event);
+      savePromises.push(this.eventRepository.save(event));
     }
+
+    await Promise.all(savePromises);
 
     return new AddEventsView(errors);
   }

--- a/server/src/Domain/HumanResource/Leave/Converter/LeaveRequestToLeavesConverter.ts
+++ b/server/src/Domain/HumanResource/Leave/Converter/LeaveRequestToLeavesConverter.ts
@@ -46,7 +46,7 @@ export class LeaveRequestToLeavesConverter {
       );
     }
 
-    this.leaveRepository.save(leaves);
+    await this.leaveRepository.save(leaves);
   }
 
   private getTime(


### PR DESCRIPTION
This will fix some edge cases where faircalendar is not refreshed correctly after an event is added