### PR TITLE
allow to set local config for containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 yarn-error.log*
 
+/docker-compose.override.yml
+
 # OS
 .DS_Store
 


### PR DESCRIPTION
If ports defined in docker-compose.yml are not well suited for local config, it's convenient to redefined them in docker-compose.override.yml.
This PR just add it to .gitignore to avoid pushing it by mistake