### PR TITLE
Add contacts create API

### DIFF
--- a/client/i18n/fr.json
+++ b/client/i18n/fr.json
@@ -136,6 +136,11 @@
   },
   "crm": {
     "breadcrumb": "FairCRM",
+    "contacts": {
+      "errors": {
+        "empty": "Le nom, prénom ou organisation est obligatoire."
+      }
+    },
     "projects": {
       "title": "Projets",
       "name": "Nom du projet",

--- a/server/migrations/1633700963101-Contact.ts
+++ b/server/migrations/1633700963101-Contact.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Contact1633700963101 implements MigrationInterface {
+  name = 'Contact1633700963101';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "contact" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "firstName" character varying, "lastName" character varying, "company" character varying, "email" character varying, "phoneNumber" character varying, "notes" character varying, CONSTRAINT "PK_2cbbe00f59ab6b3bb5b8d19f989" PRIMARY KEY ("id"))`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "contact"`);
+  }
+}

--- a/server/src/Application/Contact/Command/CreateContactCommand.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommand.ts
@@ -1,0 +1,12 @@
+import { ICommand } from 'src/Application/ICommand';
+
+export class CreateContactCommand implements ICommand {
+  constructor(
+    public readonly firstName?: string,
+    public readonly lastName?: string,
+    public readonly company?: string,
+    public readonly email?: string,
+    public readonly notes?: string,
+    public readonly phoneNumber?: string
+  ) {}
+}

--- a/server/src/Application/Contact/Command/CreateContactCommand.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommand.ts
@@ -6,7 +6,7 @@ export class CreateContactCommand implements ICommand {
     public readonly lastName?: string,
     public readonly company?: string,
     public readonly email?: string,
-    public readonly notes?: string,
-    public readonly phoneNumber?: string
+    public readonly phoneNumber?: string,
+    public readonly notes?: string
   ) {}
 }

--- a/server/src/Application/Contact/Command/CreateContactCommandHandler.spec.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommandHandler.spec.ts
@@ -1,0 +1,83 @@
+import { mock, instance, when, verify, deepEqual, anything } from 'ts-mockito';
+import { ContactRepository } from 'src/Infrastructure/Contact/Repository/ContactRepository';
+import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { CreateContactCommandHandler } from 'src/Application/Contact/Command/CreateContactCommandHandler';
+import { CreateContactCommand } from './CreateContactCommand';
+import { ro } from 'date-fns/locale';
+
+describe('CreateContactCommandHandler', () => {
+  let contactRepository: ContactRepository;
+  let createdContact: Contact;
+  let handler: CreateContactCommandHandler;
+
+  beforeEach(() => {
+    contactRepository = mock(ContactRepository);
+    handler = new CreateContactCommandHandler(instance(contactRepository));
+  });
+
+  it('testContactCreatedSuccessfully', async () => {
+    when(createdContact.getId()).thenReturn(
+      '2d5fb4da-12c2-11ea-8d71-362b9e155667'
+    );
+    when(
+      contactRepository.save(
+        deepEqual(
+          new Contact(
+            'Sarah',
+            'Conor',
+            'Aperture Science',
+            'sarah.conor@aperture.org',
+            '0612345678',
+            'Lorem ipsum'
+          )
+        )
+      )
+    ).thenResolve(instance(createdContact));
+
+    expect(
+      await handler.execute(
+        new CreateContactCommand(
+          'Sarah',
+          'Conor',
+          'Aperture Science',
+          'sarah.conor@aperture.org',
+          '0612345678',
+          'Lorem ipsum'
+        )
+      )
+    ).toBe('2d5fb4da-12c2-11ea-8d71-362b9e155667');
+
+    verify(
+      contactRepository.save(
+        deepEqual(
+          new Contact(
+            'Sarah',
+            'Conor',
+            'Aperture Science',
+            'sarah.conor@aperture.org',
+            '0612345678',
+            'Lorem ipsum'
+          )
+        )
+      )
+    ).once();
+    verify(createdContact.getId()).once();
+  });
+
+  it('testEmptyContact', async () => {
+    expect(
+      await handler.execute(
+        new CreateContactCommand(
+          null,
+          null,
+          null,
+          'sarah.conor@aperture.org',
+          '0612345678',
+          'Lorem ipsum'
+        )
+      )
+    ).toThrow(EmptyContactException);
+
+    verify(contactRepository.save(anything())).never();
+  });
+});

--- a/server/src/Application/Contact/Command/CreateContactCommandHandler.spec.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommandHandler.spec.ts
@@ -1,9 +1,9 @@
 import { mock, instance, when, verify, deepEqual, anything } from 'ts-mockito';
 import { ContactRepository } from 'src/Infrastructure/Contact/Repository/ContactRepository';
 import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { EmptyContactException } from 'src/Domain/Contact/Exception/EmptyContactException';
 import { CreateContactCommandHandler } from 'src/Application/Contact/Command/CreateContactCommandHandler';
 import { CreateContactCommand } from './CreateContactCommand';
-import { ro } from 'date-fns/locale';
 
 describe('CreateContactCommandHandler', () => {
   let contactRepository: ContactRepository;
@@ -12,6 +12,7 @@ describe('CreateContactCommandHandler', () => {
 
   beforeEach(() => {
     contactRepository = mock(ContactRepository);
+    createdContact = mock(Contact);
     handler = new CreateContactCommandHandler(instance(contactRepository));
   });
 
@@ -65,7 +66,7 @@ describe('CreateContactCommandHandler', () => {
   });
 
   it('testEmptyContact', async () => {
-    expect(
+    try {
       await handler.execute(
         new CreateContactCommand(
           null,
@@ -75,9 +76,12 @@ describe('CreateContactCommandHandler', () => {
           '0612345678',
           'Lorem ipsum'
         )
-      )
-    ).toThrow(EmptyContactException);
-
-    verify(contactRepository.save(anything())).never();
+      );
+    } catch (e) {
+      expect(e).toBeInstanceOf(EmptyContactException);
+      expect(e.message).toBe('crm.contacts.errors.empty');
+      verify(contactRepository.save(anything())).never();
+      verify(createdContact.getId()).never();
+    }
   });
 });

--- a/server/src/Application/Contact/Command/CreateContactCommandHandler.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommandHandler.ts
@@ -1,0 +1,27 @@
+import { Inject } from '@nestjs/common';
+import { CommandHandler } from '@nestjs/cqrs';
+import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { IContactRepository } from 'src/Domain/Contact/Repository/IContactRepository';
+import { CreateContactCommand } from './CreateContactCommand';
+
+@CommandHandler(CreateContactCommand)
+export class CreateContactCommandHandler {
+  constructor(
+    @Inject('IContactRepository')
+    private readonly contactRepository: IContactRepository
+  ) {}
+
+  public async execute(command: CreateContactCommand): Promise<string> {
+    const { firstName, lastName, company, phoneNumber, email, notes } = command;
+
+    if (!firstName && !lastName && !company) {
+      throw new EmptyContactException();
+    }
+
+    return (
+      await this.contactRepository.save(
+        new Contact(firstName, lastName, company, email, phoneNumber, notes)
+      )
+    ).getId();
+  }
+}

--- a/server/src/Application/Contact/Command/CreateContactCommandHandler.ts
+++ b/server/src/Application/Contact/Command/CreateContactCommandHandler.ts
@@ -1,6 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { CommandHandler } from '@nestjs/cqrs';
 import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { EmptyContactException } from 'src/Domain/Contact/Exception/EmptyContactException';
 import { IContactRepository } from 'src/Domain/Contact/Repository/IContactRepository';
 import { CreateContactCommand } from './CreateContactCommand';
 
@@ -12,16 +13,16 @@ export class CreateContactCommandHandler {
   ) {}
 
   public async execute(command: CreateContactCommand): Promise<string> {
-    const { firstName, lastName, company, phoneNumber, email, notes } = command;
+    const { firstName, lastName, company, email, phoneNumber, notes } = command;
 
     if (!firstName && !lastName && !company) {
       throw new EmptyContactException();
     }
 
-    return (
-      await this.contactRepository.save(
-        new Contact(firstName, lastName, company, email, phoneNumber, notes)
-      )
-    ).getId();
+    const contact = await this.contactRepository.save(
+      new Contact(firstName, lastName, company, email, phoneNumber, notes)
+    );
+
+    return contact.getId();
   }
 }

--- a/server/src/Domain/Contact/Contact.entity.spec.ts
+++ b/server/src/Domain/Contact/Contact.entity.spec.ts
@@ -16,7 +16,7 @@ describe('Contact.entity', () => {
     expect(contact.getLastName()).toBe('Conor');
     expect(contact.getCompany()).toBe('Aperture Science');
     expect(contact.getEmail()).toBe('sarah.conor@aperture.org');
-    expect(contact.getPhoneNumber()).toBe('012345678');
+    expect(contact.getPhoneNumber()).toBe('0612345678');
     expect(contact.getNotes()).toBe('Lorem ipsum');
   });
 });

--- a/server/src/Domain/Contact/Contact.entity.spec.ts
+++ b/server/src/Domain/Contact/Contact.entity.spec.ts
@@ -1,0 +1,22 @@
+import { Contact } from './Contact.entity';
+
+describe('Contact.entity', () => {
+  it('testGetters', () => {
+    const contact = new Contact(
+      'Sarah',
+      'Conor',
+      'Aperture Science',
+      'sarah.conor@aperture.org',
+      '0612345678',
+      'Lorem ipsum'
+    );
+
+    expect(contact.getId()).toBe(undefined);
+    expect(contact.getFirstName()).toBe('Sarah');
+    expect(contact.getLastName()).toBe('Conor');
+    expect(contact.getCompany()).toBe('Aperture Science');
+    expect(contact.getEmail()).toBe('sarah.conor@aperture.org');
+    expect(contact.getPhoneNumber()).toBe('012345678');
+    expect(contact.getNotes()).toBe('Lorem ipsum');
+  });
+});

--- a/server/src/Domain/Contact/Contact.entity.ts
+++ b/server/src/Domain/Contact/Contact.entity.ts
@@ -1,0 +1,76 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Contact {
+  @PrimaryGeneratedColumn('uuid')
+  private id: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  private createdAt: Date;
+
+  @Column({ type: 'varchar', nullable: true })
+  private firstName: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  private lastName: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  private company: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  private email: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  private phoneNumber: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  private notes: string;
+
+  constructor(
+    firstName: string,
+    lastName: string,
+    company: string,
+    email: string,
+    phoneNumber: string,
+    notes: string
+  ) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.company = company;
+    this.email = email;
+    this.phoneNumber = phoneNumber;
+    this.notes = notes;
+  }
+
+  public getId(): string | null {
+    return this.id;
+  }
+
+  public getCreatedAt(): Date {
+    return this.createdAt;
+  }
+
+  public getFirstName(): string | null {
+    return this.firstName;
+  }
+
+  public getLastName(): string | null {
+    return this.lastName;
+  }
+
+  public getCompany(): string | null {
+    return this.company;
+  }
+
+  public getEmail(): string | null {
+    return this.email;
+  }
+
+  public getPhoneNumber(): string {
+    return this.phoneNumber;
+  }
+
+  public getNotes(): string {
+    return this.notes;
+  }
+}

--- a/server/src/Domain/Contact/Exception/EmptyContactException.ts
+++ b/server/src/Domain/Contact/Exception/EmptyContactException.ts
@@ -1,0 +1,5 @@
+class EmptyContactException extends Error {
+  constructor() {
+    super('crm.contacts.errors.empty');
+  }
+}

--- a/server/src/Domain/Contact/Exception/EmptyContactException.ts
+++ b/server/src/Domain/Contact/Exception/EmptyContactException.ts
@@ -1,4 +1,4 @@
-class EmptyContactException extends Error {
+export class EmptyContactException extends Error {
   constructor() {
     super('crm.contacts.errors.empty');
   }

--- a/server/src/Domain/Contact/Repository/IContactRepository.ts
+++ b/server/src/Domain/Contact/Repository/IContactRepository.ts
@@ -1,0 +1,5 @@
+import { Contact } from '../Contact.entity';
+
+export interface IContactRepository {
+  save(contact: Contact): Promise<Contact>;
+}

--- a/server/src/Infrastructure/Contact/Action/CreateContactAction.ts
+++ b/server/src/Infrastructure/Contact/Action/CreateContactAction.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Post,
+  Controller,
+  Inject,
+  BadRequestException,
+  UseGuards
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ICommandBus } from 'src/Application/ICommandBus';
+import { ContactDTO } from '../DTO/ContactDTO';
+import { RolesGuard } from 'src/Infrastructure/HumanResource/User/Security/RolesGuard';
+import { UserRole } from 'src/Domain/HumanResource/User/User.entity';
+import { Roles } from 'src/Infrastructure/HumanResource/User/Decorator/Roles';
+import { CreateContactCommand } from 'src/Application/Contact/Command/CreateContactCommand';
+
+@Controller('contacts')
+@ApiTags('Contact')
+@ApiBearerAuth()
+@UseGuards(AuthGuard('bearer'), RolesGuard)
+export class CreateContactAction {
+  constructor(
+    @Inject('ICommandBus')
+    private readonly commandBus: ICommandBus
+  ) {}
+
+  @Post()
+  @Roles(UserRole.COOPERATOR, UserRole.EMPLOYEE)
+  @ApiOperation({ summary: 'Create new contact' })
+  public async index(@Body() contactDto: ContactDTO) {
+    const {
+      firstName,
+      lastName,
+      company,
+      email,
+      phoneNumber,
+      notes
+    } = contactDto;
+
+    try {
+      const id = await this.commandBus.execute(
+        new CreateContactCommand(
+          firstName,
+          lastName,
+          company,
+          email,
+          phoneNumber,
+          notes
+        )
+      );
+
+      return { id };
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+}

--- a/server/src/Infrastructure/Contact/DTO/ContactDTO.spec.ts
+++ b/server/src/Infrastructure/Contact/DTO/ContactDTO.spec.ts
@@ -1,0 +1,30 @@
+import { ContactDTO } from './ContactDTO';
+import { validate } from 'class-validator';
+
+describe('ContactDTO', () => {
+  it('testValidDTO', async () => {
+    const contactDTO = new ContactDTO();
+    contactDTO.firstName = 'John';
+    contactDTO.lastName = 'Doe';
+    contactDTO.company = 'Acme';
+    contactDTO.email = 'john@doe.com';
+    contactDTO.phoneNumber = '+33611223344';
+    contactDTO.notes = 'Lorem ipsum dolor sit amet';
+
+    const validation = await validate(contactDTO);
+    expect(validation).toHaveLength(0);
+  });
+
+  it('testInvalidDTO', async () => {
+    const dto = new ContactDTO();
+
+    const validation = await validate(dto);
+    expect(validation).toHaveLength(2);
+    expect(validation[0].constraints).toMatchObject({
+      isNotEmpty: 'name should not be empty'
+    });
+    expect(validation[1].constraints).toMatchObject({
+      isNotEmpty: 'address should not be empty'
+    });
+  });
+});

--- a/server/src/Infrastructure/Contact/DTO/ContactDTO.spec.ts
+++ b/server/src/Infrastructure/Contact/DTO/ContactDTO.spec.ts
@@ -16,15 +16,17 @@ describe('ContactDTO', () => {
   });
 
   it('testInvalidDTO', async () => {
-    const dto = new ContactDTO();
+    const contactDTO = new ContactDTO();
+    contactDTO.email = 'obviously not a valid email';
+    contactDTO.phoneNumber = 'obviously not a valid phone number';
 
-    const validation = await validate(dto);
+    const validation = await validate(contactDTO);
     expect(validation).toHaveLength(2);
     expect(validation[0].constraints).toMatchObject({
-      isNotEmpty: 'name should not be empty'
+      isEmail: 'email must be an email'
     });
     expect(validation[1].constraints).toMatchObject({
-      isNotEmpty: 'address should not be empty'
+      isPhoneNumber: 'phoneNumber must be a valid phone number'
     });
   });
 });

--- a/server/src/Infrastructure/Contact/DTO/ContactDTO.ts
+++ b/server/src/Infrastructure/Contact/DTO/ContactDTO.ts
@@ -1,0 +1,30 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsPhoneNumber, IsEmail } from 'class-validator';
+
+export class ContactDTO {
+  @ApiPropertyOptional()
+  @IsOptional()
+  public firstName: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  public lastName: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  public company: string;
+
+  @ApiPropertyOptional()
+  @IsEmail()
+  @IsOptional()
+  public email: string;
+
+  @ApiPropertyOptional()
+  @IsPhoneNumber('FR')
+  @IsOptional()
+  public phoneNumber: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  public notes: string;
+}

--- a/server/src/Infrastructure/Contact/Repository/ContactRepository.ts
+++ b/server/src/Infrastructure/Contact/Repository/ContactRepository.ts
@@ -1,8 +1,10 @@
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Contact } from 'src/Domain/Contact/Contact.entity';
 import { IContactRepository } from 'src/Domain/Contact/Repository/IContactRepository';
 import { Repository } from 'typeorm';
 
+@Injectable()
 export class ContactRepository implements IContactRepository {
   constructor(
     @InjectRepository(Contact)

--- a/server/src/Infrastructure/Contact/Repository/ContactRepository.ts
+++ b/server/src/Infrastructure/Contact/Repository/ContactRepository.ts
@@ -1,0 +1,15 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { IContactRepository } from 'src/Domain/Contact/Repository/IContactRepository';
+import { Repository } from 'typeorm';
+
+export class ContactRepository implements IContactRepository {
+  constructor(
+    @InjectRepository(Contact)
+    private readonly repository: Repository<Contact>
+  ) {}
+
+  public save(contact: Contact): Promise<Contact> {
+    return this.repository.save(contact);
+  }
+}

--- a/server/src/Infrastructure/Contact/contact.module.ts
+++ b/server/src/Infrastructure/Contact/contact.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BusModule } from '../bus.module';
+import { Contact } from 'src/Domain/Contact/Contact.entity';
+import { CreateContactAction } from './Action/CreateContactAction';
+import { ContactRepository } from './Repository/ContactRepository';
+import { CreateContactCommandHandler } from 'src/Application/Contact/Command/CreateContactCommandHandler';
+
+@Module({
+  imports: [BusModule, TypeOrmModule.forFeature([Contact])],
+  controllers: [CreateContactAction],
+  providers: [
+    { provide: 'IContactRepository', useClass: ContactRepository },
+    CreateContactCommandHandler
+  ]
+})
+export class ContactModule {}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { FairCalendarModule } from './Infrastructure/FairCalendar/faircalendar.m
 import { FileModule } from './Infrastructure/File/file.module';
 import { HumanResourceModule } from './Infrastructure/HumanResource/humanResource.module';
 import { SettingsModule } from './Infrastructure/Settings/settings.module';
+import { ContactModule } from './Infrastructure/Contact/contact.module';
 
 @Module({
   imports: [
@@ -21,7 +22,8 @@ import { SettingsModule } from './Infrastructure/Settings/settings.module';
     HumanResourceModule,
     ProjectModule,
     TaskModule,
-    SettingsModule
+    SettingsModule,
+    ContactModule
   ]
 })
 export class AppModule {}


### PR DESCRIPTION
Refs #153 (partie 1)

### Description

Cette PR démarre une fonctionnalité "contacts" / "prospects", sur un mode CRM (Customer Relationship Management) :

* Ajout d'un endpoint `POST /api/contacts` permettant de créer un contact
* Tests associés.
* Mise à jour du schéma de la BDD (migration).

Aperçu de la doc mise à jour :

![contacts-post](https://user-images.githubusercontent.com/15911462/139862493-e69a6eb4-1fb9-46e0-b3fd-7a76e6262a05.png) (35kB)

### Motivation

Démarrer #153 dans le back. Viendront ensuite les actions Get / List / Update / Delete.

Next step : avancer le CRUD et le front branché sur l'API.

### Notes

* "Contact" ou "Prospect" ? #153 parle de "people we have met so everyone knows what bond we have with them" -> C'est donc bien dans une philosophie "personne connue" / "carnet d'adresse" que l'on démarre cette fonctionnalité-ci. Le process de prospection pourra être ajouté / formalisé plus tard.