### PR TITLE
Expose database container port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - 'database:/var/lib/postgresql/data'
     ports:
-      - 5454:5432
+      - 5432:5432
 
   api:
     image: node:14.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       PGPASSWORD: docker
     volumes:
       - 'database:/var/lib/postgresql/data'
+    ports:
+      - 5454:5432
 
   api:
     image: node:14.3


### PR DESCRIPTION
**Description**
Cette PR modifie `docker-compose.yml` pour que le port de la DB soit exposé sur `localhost:5432`.

**Motivation**
Permet plus facilement de connecter des outils de l'hôte vers la DB, comme Postico, SQLExplorer, un IDE, etc, pour se balader dans les tables et manipuler les données.