### PR TITLE
Add missing employee permissions on DELETE /contacts/:id

### DIFF
--- a/server/src/Infrastructure/Contact/Action/DeleteContactAction.ts
+++ b/server/src/Infrastructure/Contact/Action/DeleteContactAction.ts
@@ -26,7 +26,7 @@ export class DeleteContactAction {
   ) {}
 
   @Delete(':id')
-  @Roles(UserRole.COOPERATOR)
+  @Roles(UserRole.COOPERATOR, UserRole.EMPLOYEE)
   @ApiOperation({ summary: 'Delete contact' })
   public async index(@Param() dto: IdDTO) {
     try {


### PR DESCRIPTION
À la suite du déploiement de #216,

Je ne pouvais pas retirer un contact de test en prod : j'obtenais un `403` :

```
Forbidden ressource
```

En effet, les permissions sur `DELETE /contacts/:id` n'incluaient pas le rôle `EMPLOYEE`, contrairement aux autres endpoints. Le copier-coller a ses limites… 😉 