### PR TITLE
Clarify Node.js prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Permacoop is an open source and eco design ERP solution reserved for worker-owne
 
 You must have **[Docker](https://www.docker.com/)** and **[Docker Compose](https://docs.docker.com/compose/)**.
 
+Ensure you have [Node.js](https://nodejs.org) v14.3 and `node-gyp` installed globally (`npm install -g node-gyp`). (Node version should match to avoid any build issues with binary dependencies such as `argon2`.)
+
 ## Installation
 
 At **the first launch**, just execute this command to install your application :


### PR DESCRIPTION
Ajoute une ligne au README.md avec les prérequis niveau Node.js pour que l'installation se passe sans encombre.

En effet sur ma nouvelle machine j'avais installé Node LTS (16), mais je rencontrais des problèmes avec argon2 : un message "undefined variable module_name", puis, en installant manuellement dans le container, un message à l'import par l'app "GLIBC 2.25 not found".

En installant la version correspondant au `docker-compose.yml` (14.3 en l'occurrence), les problèmes se sont résolus, car le build avait lieu dans les mêmes conditions entre l'hôte et le container.