### PR TITLE
Cleanup Dockerized CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Tests
-        run: |
-          docker-compose build api
-          make ci
+        run: make ci
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install: ## Install API and client
 	cp server/.env.dist server/.env
 	cp client/config.js.dist client/config.js
 	make start-container
+	make api-build-dist
 	make database-migrate
 	make watch-tailwind
 stop: ## Stop docker containers

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,9 +6,8 @@ WORKDIR /var/www
 COPY ./package.json ./package-lock.json ./
 RUN npm install
 
-# Bundle app and run default build
+# Bundle app
 COPY ./ ./
-RUN npm run build
 
 EXPOSE 3000
 


### PR DESCRIPTION
Cleanup for #224 

Don't `npm run build` on CI, as we used to.