### PR TITLE
Bring back leaves nav item

### DIFF
--- a/client/src/components/Nav.svelte
+++ b/client/src/components/Nav.svelte
@@ -188,6 +188,11 @@
               <li class={subLinkClass}>
                 <a
                   class="w-full"
+                  href="human_resources/leaves">{$_('human_resources.leaves.title')}</a>
+              </li>
+              <li class={subLinkClass}>
+                <a
+                  class="w-full"
                   href="human_resources/payslips">{$_('human_resources.payslips.breadcrumb')}</a>
               </li>
               <li class={subLinkClass}>


### PR DESCRIPTION
**Motivation**

Lors de #248, le nav item "Fiches de paie" a remplacé "Congés", au lieu d'être ajouté à la suite

Voir : https://github.com/fairnesscoop/permacoop/pull/248/files#diff-4ee18bd98ed9e10b65cf35639af27f76c4053c13ed3491f8491a402c54dc2bacR191

Par conséquent, il n'est actuellement plus possible d'accéder aux congés dans la nav sur https://permacoop.fairness.coop, même si https://permacoop.fairness.coop/human_resources/leaves existe toujours

**Description**

Cette PR remet le nav item "Congés"

**Aperçu**

Avant / après

![Screenshot 2022-05-23 at 13-14-17 Congés - Permacoop](https://user-images.githubusercontent.com/15911462/169807828-28dfc2b0-fa1c-417e-9443-75ebad15447c.png) ![Screenshot 2022-05-23 at 13-14-02 Congés - Permacoop](https://user-images.githubusercontent.com/15911462/169807834-f031db70-607f-48aa-87b6-ae92ff3c9118.png)

