### PR TITLE
Deploy via Ansible to permacoop.fairness.coop

### DIFF
--- a/ansible/environments/prod/hosts
+++ b/ansible/environments/prod/hosts
@@ -1,2 +1,2 @@
 [web]
-permacoop2.fairness.coop ansible_user=root
+permacoop.fairness.coop ansible_user=root

--- a/prod/README.md
+++ b/prod/README.md
@@ -46,6 +46,7 @@ Deployment must be performed in the terminal.
 **Prerequisites**
 
 * You must have SSH access to the production server.
+* Ensure Python 3.8+ is installed on your machine (on Linux: `apt install python3.8-venv`).
 * You must have the Vault password in `ansible/vault-password` (this file is ignored by git). Ask a team member to share it with you securely.
 
 Move to the Ansible directory:


### PR DESCRIPTION
Suite à #276, le déploiement sur permacoop2.fairness.coop a réussi, donc cette PR passe le déploiement sur permacoop.fairness.coop.

Ajoute aussi la dépendance explicite à Python3 pour lancer les commandes Ansible.