### PR TITLE
Ensure CI passes before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,17 @@
 name: Deployment
+
 on:
   push:
     branches:
        - master
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - master
+    types:
+      - completed
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Actuellement, quand on merge une PR sur `master`, le workflow `deploy.yml` se lance avant même que `ci.yml` n'ait le temps de terminer.

Il y a donc un risque de déployer du code qui pourrait casser la CI et donc être incorrect (si jamais quelque chose a passé les mailles de la revue de code).

Cette PR ajoute [workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) à `deploy.yml` pour ne déployer que lorsque la CI a abouti avec succès.