### PR TITLE
Fix workflow_run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deployment
 
 on:
-  push:
-    branches:
-       - master
   workflow_run:
     workflows:
       - CI

--- a/ansible/roles/web/tasks/supervisor.yml
+++ b/ansible/roles/web/tasks/supervisor.yml
@@ -14,12 +14,6 @@
   become: true
   notify: reload nginx
 
-# Drop 'client' process which ran before implementing sapper/sveltekit facade
-- name: Ensure client is stopped
-  supervisorctl: name=client state=stopped
-  become: true
-  notify: reload nginx
-
 - name: Ensure client-legacy is running
   supervisorctl: name=client-legacy state=present
   become: true


### PR DESCRIPTION
Correctif de #305... En fait si on garde `push`, alors le workflow deploy.yml se lance 2 fois : une fois lors du push, une deuxième fois quand `ci.yml` a terminé... Il faut donc garder seulement `workflow_run`.

Je passe aussi un fix suite à #306... Il semble que `supervisorctl` ne soit pas très "isomorphe" : la tâche échoue si le process visé n'existe pas, au lieu de ne rien faire... Comme ça a été déployé, effectivement le process `client` n'existe plus donc je retire la tâche.