### PR TITLE
Always reload supervisor after a deployment

### DIFF
--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,7 +1,3 @@
 - name: reload nginx
   service: name=nginx state=reloaded
   become: true
-
-- name: reload supervisor
-  service: name=supervisor state=reloaded
-  become: true

--- a/ansible/roles/web/tasks/git.yml
+++ b/ansible/roles/web/tasks/git.yml
@@ -6,5 +6,3 @@
     force: true
   environment:
     GIT_TERMINAL_PROMPT: "0"
-  # Code may have changed, so restart the servers.
-  notify: reload supervisor

--- a/ansible/roles/web/tasks/supervisor.yml
+++ b/ansible/roles/web/tasks/supervisor.yml
@@ -6,8 +6,6 @@
     group: root
     mode: 0644
   become: true
-  # Config or dependencies may have changed, so restart the server.
-  notify: reload supervisor
 
 - name: Ensure api is running
   supervisorctl: name=api state=present
@@ -23,3 +21,7 @@
   supervisorctl: name=client-kit state=present
   become: true
   notify: reload nginx
+
+- name: Ensure supervisor has reloaded
+  service: name=supervisor state=reloaded
+  become: true


### PR DESCRIPTION
Closes #313 

En fait quand on déploie sans changement de code, le handler `notify: reload supervisor` n'était jamais déclenché.

Donc supervisor ne rechargeait pas et donc c'était encore l'ancienne version du build SvelteKit qui tournait, or les fichiers avaient changé ! D'où l'import error...