### PR TITLE
Refine user elements page name and CSV generation

### DIFF
--- a/client/kit/src/lib/i18n/fr.json
+++ b/client/kit/src/lib/i18n/fr.json
@@ -267,7 +267,7 @@
       }
     },
     "payslips": {
-      "breadcrumb": "Fiches de paies",
+      "breadcrumb": "Éléments de paie",
       "title": "Éléments pour les fiches de paie",
       "user": "Salairé / stagiaire",
       "contract": "Type de contrat",

--- a/client/legacy/i18n/fr.json
+++ b/client/legacy/i18n/fr.json
@@ -267,7 +267,7 @@
       }
     },
     "payslips": {
-      "breadcrumb": "Fiches de paies",
+      "breadcrumb": "Éléments de paie",
       "title": "Éléments pour les fiches de paie",
       "user": "Salairé / stagiaire",
       "contract": "Type de contrat",

--- a/client/legacy/src/routes/human_resources/payslips/index.svelte
+++ b/client/legacy/src/routes/human_resources/payslips/index.svelte
@@ -30,18 +30,23 @@
   });
 
   const getCsvAsbase64 = async () => {
-    const csv = await get('payslips.csv');
-    const csvFile = new Blob([csv.data], { type: "text/csv" });
-
-    return window.URL.createObjectURL(csvFile);
-  }
+    try {
+      const csv = await get('payslips.csv');
+      const csvFile = new Blob([csv.data], { type: 'text/csv' });
+      return window.URL.createObjectURL(csvFile);
+    } catch (e) {
+      errors = errorNormalizer(e);
+      return "#";
+    }
+  };
 </script>
 
 <svelte:head>
   <title>{title} - {$_('app')}</title>
 </svelte:head>
 
-<Breadcrumb items={[{ title: $_('human_resources.breadcrumb') }, { title: $_('human_resources.payslips.breadcrumb') }]} />
+<Breadcrumb
+  items={[{ title: $_('human_resources.breadcrumb') }, { title: $_('human_resources.payslips.breadcrumb') }]} />
 <ServerErrors {errors} />
 <div class="inline-flex items-center">
   <H4Title {title} />
@@ -54,5 +59,12 @@
     </a>
   {/await}
 
+  <a
+    href="https://gitlab.fairness.coop/fairness/documentation/-/wikis/Paiement-des-salaires"
+    class="px-2 py-1 mb-6 ml-2 text-sm font-medium leading-5 bg-purple-200 border rounded-lg"
+    rel="noreferrer"
+    target="_blank">
+    Voir le Wiki <span aria-hidden="true">↗</span>
+  </a>
 </div>
 <Table items={payslipElements} />

--- a/client/legacy/src/routes/human_resources/payslips/index.svelte
+++ b/client/legacy/src/routes/human_resources/payslips/index.svelte
@@ -53,7 +53,7 @@
   {#await getCsvAsbase64() then csvObjectUrl}
     <a
       href={csvObjectUrl}
-      download={`payslips-${month.replace(' ', '-')}.csv`}
+      download={`Fairness - Éléments de paie - ${month.replace(' ', '-')}.csv`}
       class="px-2 py-1 mb-6 ml-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
       {$_('human_resources.payslips.download')}
     </a>

--- a/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
+++ b/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
@@ -25,7 +25,7 @@ export class GetUsersElementsCsvAction {
 
     const month = date.toISOString().substring(0, 7);
 
-    res.attachment(`playslips-${month}.csv`);
+    res.attachment(`Fairness - Éléments de paie - ${month}.csv`);
 
     const payslips: UserElementsView[] = await this.queryBus.execute(
       new GetUsersElementsQuery(date)


### PR DESCRIPTION
Closes #319 

Cette PR:

* Renomme la page "Fiches de paies" en "Éléments de paie"
* Ajoute un lien vers le Wiki directement sur la page
* Traduit les colonnes du CSV en français
* Ajoute une ligne dans le CSV par congé payé, plutôt qu'une seule case avec chaque période
* Ajoute une colonne "Notes" vide
* Traduit le nom de fichier téléchargé en français
* Ajoute de l'error handling pour éviter le plantage lors du hot reload sur la page

Exemple de CSV généré en PJ

[Fairness - Éléments de paie - décembre-2022.csv](https://github.com/fairnesscoop/permacoop/files/10239063/Fairness.-.Elements.de.paie.-.decembre-2022.csv)