### PR TITLE
Rework stop/rm/ps commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ install-client-kit: ## Install SvelteKit client
 install-client-e2e: ## Install E2E client dependencies
 	cd client/kit && npx playwright install firefox
 
-start: compose-up ## Start containers, API and client
+start: ## Start containers, API and client
+	make compose CMD="up -d"
 	make -j 2 start-api start-client
 
 start-api: ## Run API
@@ -56,16 +57,13 @@ start-client-kit: ## Run SvelteKit client
 compose: ## Run Docker compose command (args: CMD)
 	${compose} ${CMD}
 
-compose-up: ## Start containers
-	make compose CMD="up -d"
-
-compose-stop: ## Stop containers
+stop: ## Stop containers
 	make compose CMD=stop
 
-compose-rm: compose-stop  ## Stop and remove containers
+rm: stop  ## Stop and remove containers
 	make compose CMD=rm
 
-compose-ps: ## Show running containers
+ps: ## Show running containers
 	make compose CMD=ps
 
 build: build-api build-client ## Build API and client
@@ -156,7 +154,7 @@ database-connect: ## Connect to the database container
 	${compose} exec database psql -h database -d permacoop
 
 ci: ## Run CI checks
-	make compose-up
+	make compose CMD="up -d"
 	make install
 	make install-client-e2e
 	make build

--- a/README.md
+++ b/README.md
@@ -35,22 +35,16 @@ First, install dependencies:
 make install
 ```
 
-Then start the database and other services:
+Then start the servers, database and other services:
 
 ```
-make compose-up
+make start
 ```
 
-You can now run database migrations:
+In a separate terminal, run database migrations:
 
 ```
 make database-migrate
-```
-
-You can now start the application using:
-
-```bash
-make start
 ```
 
 The server and client will be started:


### PR DESCRIPTION
Les commandes de type `make compose-stop`, `make compose-rm` etc sont fatiguantes.

@mmarchois semblait préférer `make stop`, `make rm`, `make ps`. On a déjà `make start` alors ça semble bien.