### PR TITLE
Add missing UID property in leaves calendar

### DIFF
--- a/server/src/Application/HumanResource/Leave/Query/GetLeavesCalendarQueryHandler.spec.ts
+++ b/server/src/Application/HumanResource/Leave/Query/GetLeavesCalendarQueryHandler.spec.ts
@@ -25,6 +25,7 @@ describe('GetLeavesCalendarQueryHandler', () => {
     const user = mock(User);
     when(user.getFullName()).thenReturn('Jane Dean');
 
+    const uuid = '3008a48d-99db-44c4-bf3a-75e95c47bd1a';
     const startDate = new Date(
       'Thu Nov 03 2022 12:00:00 GMT+0100 (Central European Standard Time)'
     );
@@ -46,6 +47,7 @@ describe('GetLeavesCalendarQueryHandler', () => {
     ).thenReturn('20221106');
 
     const leaveRequest = mock(LeaveRequest);
+    when(leaveRequest.getId()).thenReturn(uuid);
     when(leaveRequest.getStartDate()).thenReturn(startDate.toISOString());
     when(leaveRequest.getEndDate()).thenReturn(endDate.toISOString());
     when(leaveRequest.getUser()).thenReturn(instance(user));
@@ -63,9 +65,11 @@ describe('GetLeavesCalendarQueryHandler', () => {
     expect(lines.shift()).toBe('PRODID:-//Fairness//Permacoop//FR');
     expect(lines.shift()).toBe('CALSCALE:GREGORIAN');
     expect(lines.shift()).toBe('X-WR-CALNAME:Congés Fairness');
+    expect(lines.shift()).toBe('NAME:Congés Fairness');
     expect(lines.shift()).toBe('X-APPLE-CALENDAR-COLOR:#00CA9E');
 
     expect(lines.shift()).toBe('BEGIN:VEVENT');
+    expect(lines.shift()).toBe('UID:3008a48d-99db-44c4-bf3a-75e95c47bd1a');
     expect(lines.shift()).toBe('DTSTART;VALUE=DATE:20221103');
     expect(lines.shift()).toBe('DTEND;VALUE=DATE:20221106');
     expect(lines.shift()).toBe('SUMMARY:Congés Jane Dean');

--- a/server/src/Application/HumanResource/Leave/Query/GetLeavesCalendarQueryHandler.ts
+++ b/server/src/Application/HumanResource/Leave/Query/GetLeavesCalendarQueryHandler.ts
@@ -24,6 +24,7 @@ export class GetLeavesCalendarQueryHandler {
       'PRODID:-//Fairness//Permacoop//FR',
       'CALSCALE:GREGORIAN',
       'X-WR-CALNAME:Congés Fairness',
+      'NAME:Congés Fairness',
       'X-APPLE-CALENDAR-COLOR:#00CA9E'
     ];
 
@@ -40,6 +41,7 @@ export class GetLeavesCalendarQueryHandler {
 
       lines.push(
         'BEGIN:VEVENT',
+        `UID:${leaveRequest.getId()}`,
         `DTSTART;VALUE=DATE:${this.dateUtils.format(
           inclusiveStartDate,
           'yyyyMMdd'


### PR DESCRIPTION
Correctif suite à #325, closes #284 : sur ProtonCalendar l'import ne fonctionnait pas.

Après comparaison avec [Jours fériés métropole](https://www.data.gouv.fr/fr/datasets/jours-feries-en-france/), et vérification dans [RFC 5545 (3.8.4.7 Unique Identifier)](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.7), je pense que ça vient du fait qu'il manque la propriété obligatoire `UID`.

Je ne peux pas importer dans ProtonCalendar à partir de localhost donc pas moyen de tester que ça règle bien le pb dans ProtonCalendar avant de déployer.

Checklist

* [x] Tests unitaires mis à jour
* [x] Import dans Thunderbird toujours OK 