### PR TITLE
Fix "UID=undefined" in leaves calendar

### DIFF
--- a/server/src/Infrastructure/HumanResource/Leave/Repository/LeaveRequestRepository.ts
+++ b/server/src/Infrastructure/HumanResource/Leave/Repository/LeaveRequestRepository.ts
@@ -118,6 +118,7 @@ export class LeaveRequestRepository implements ILeaveRequestRepository {
     const query = this.repository
       .createQueryBuilder('leaveRequest')
       .select([
+        'leaveRequest.id',
         'leaveRequest.startDate',
         'leaveRequest.endDate',
         'user.firstName',


### PR DESCRIPTION
Refs #284 

On avait `UID=undefined` car `leaveRequest.getId()` renvoyait `undefined` au runtime, car on ne le chargeait pas dans la requête SQL.