### PR TITLE
Feat/allow employee to delete leave

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ make database-migrate
 Then, you can seed the database with fake data
 
 ```
-make seed-database
+make database-seed
 ```
 
 This command will create the default user "John Doe" :
@@ -128,7 +128,6 @@ make database-migration NAME=add_some_column
 ## Security
 
 The client must send the user `apiToken` in the Authorization header when making requests to protected resources : `Authorization: Bearer <apiToken>`
-
 
 To retrieve the `apiToken`, make a post request on `/login` with a user email and password.
 

--- a/server/src/Infrastructure/HumanResource/Leave/Action/DeleteLeaveRequestAction.ts
+++ b/server/src/Infrastructure/HumanResource/Leave/Action/DeleteLeaveRequestAction.ts
@@ -27,7 +27,7 @@ export class DeleteLeaveRequestAction {
   ) {}
 
   @Delete(':id')
-  @Roles(UserRole.COOPERATOR)
+  @Roles(UserRole.COOPERATOR, UserRole.EMPLOYEE)
   @ApiOperation({ summary: 'Delete leave request' })
   public async index(@Param() { id }: IdDTO, @LoggedUser() user: User) {
     try {


### PR DESCRIPTION
As a user with the "Employee" role, I would like to be able to delete my own leave requests after they've been accepted.

For now, only users with the "Collaborator" role could remove their own leave requests.