### PR TITLE
Corrige le pattern de code postal client

### DIFF
--- a/client/legacy/src/routes/crm/customers/_Form.svelte
+++ b/client/legacy/src/routes/crm/customers/_Form.svelte
@@ -11,7 +11,6 @@
 
   const address = customer.address;
   const dispatch = createEventDispatcher();
-  const zipCodePattern = /\d{5}/;
 
   const submit = () => {
     dispatch('save', customer);
@@ -25,7 +24,7 @@
   <Input label={$_('crm.customers.form.address')} bind:value={address.street} />
   <Input
     label={$_('crm.customers.form.zip_code')}
-    bind:value={address.zipCode} pattern={zipCodePattern} />
+    bind:value={address.zipCode} pattern={'\\d{5}'} />
   <Input label={$_('crm.customers.form.city')} bind:value={address.city} />
   <SelectInput
     label={$_('crm.customers.form.country')}


### PR DESCRIPTION
Signalé par @hmmarchois, je l'avais vu aussi et je pensais avoir mis un ticket pour le signaler mais ce n'est pas le cas, voilà le correctif

> C'est quoi le format requis pour les codes postaux quand on rajoute un client? J'ai l'impression que je suis l'utilisatrice relou qui pige rien. 