### PR TITLE
Use more realistic transport fee

### DIFF
--- a/server/src/DataSeeding/Factories/UserAdministrativeFactory.ts
+++ b/server/src/DataSeeding/Factories/UserAdministrativeFactory.ts
@@ -19,7 +19,7 @@ export class UserAdministrativeFactory extends Factory<UserAdministrative> {
       WorkingTimeType.FULL_TIME,
       dateUtils.format(faker.date.past(), 'y-MM-dd'),
       null,
-      700 * 100
+      60 * 100
     );
 
     return userAdministrative;


### PR DESCRIPTION
Suite à #366 

Les 700€ devaient correspondre à un montant annuel, mais `transportFee` est un nombre de centimes mensuels => On peut dire plutôt 60€