### PR TITLE
Update link to Paie wiki

### DIFF
--- a/client/legacy/src/routes/human_resources/payslips/index.svelte
+++ b/client/legacy/src/routes/human_resources/payslips/index.svelte
@@ -60,7 +60,7 @@
   {/await}
 
   <a
-    href="https://gitlab.fairness.coop/fairness/documentation/-/wikis/Paiement-des-salaires"
+    href="https://gitlab.fairness.coop/fairness/documentation/-/wikis/Salaires-et-fiches-de-paie"
     class="px-2 py-1 mb-6 ml-2 text-sm font-medium leading-5 bg-purple-200 border rounded-lg"
     rel="noreferrer"
     target="_blank">


### PR DESCRIPTION
J'ai renommé la page du wiki "Paiement des salaires" en "Salaires et fiches de paie"

Donc le lien utile dans Permacoop change

Pour l'instant l'ancienne page existe tjr : https://gitlab.fairness.coop/fairness/documentation/-/wikis/Paiement-des-salaires et pointe vers la nouvelle

Une fois cette PR mergée et déployée je supprimerai l'ancienne page