### PR TITLE
Fix payslip csv format

### DIFF
--- a/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
+++ b/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
@@ -9,7 +9,7 @@ import { format } from 'date-fns';
 import { LeaveRequestSlotView } from 'src/Application/HumanResource/Leave/View/LeaveRequestSlotView';
 
 const formatFrNumber = (n: number) =>
-  n.toLocaleString('fr-FR').replace(' ', '');
+  n.toLocaleString('fr-FR').replaceAll(' ', '');
 
 @Controller('payslips.csv')
 @ApiCookieAuth()

--- a/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
+++ b/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
@@ -8,6 +8,9 @@ import { Response } from 'express';
 import { format } from 'date-fns';
 import { LeaveRequestSlotView } from 'src/Application/HumanResource/Leave/View/LeaveRequestSlotView';
 
+const formatFrNumber = (n: number) =>
+  n.toLocaleString('fr-FR').replace(' ', '');
+
 @Controller('payslips.csv')
 @ApiCookieAuth()
 @UseGuards(AuthGuard('bearer'))
@@ -32,8 +35,8 @@ export class GetUsersElementsCsvAction {
     );
 
     const headers = [
+      'NOM',
       'Prénom',
-      'Nom',
       'Contrat',
       "Date d'entrée",
       'Salaire annuel brut',
@@ -58,21 +61,21 @@ export class GetUsersElementsCsvAction {
 
     for (const payslip of payslips) {
       const row = [
+        payslip.lastName.toUpperCase(),
         payslip.firstName,
-        payslip.lastName,
         payslip.contract,
         payslip.joiningDate,
-        payslip.annualEarnings,
-        payslip.monthlyEarnings.toFixed(2),
+        formatFrNumber(payslip.annualEarnings),
+        formatFrNumber(Math.round(payslip.monthlyEarnings * 100) / 100),
         payslip.workingTime === 'full_time' ? 'Temps plein' : 'Temps partiel',
-        payslip.transportFee,
-        payslip.sustainableMobilityFee,
+        formatFrNumber(payslip.transportFee),
+        formatFrNumber(payslip.sustainableMobilityFee),
         payslip.mealTickets,
         payslip.healthInsurance === 'yes' ? 'Oui' : 'Non',
-        payslip.paidLeaves.totalDays,
-        payslip.unpaidLeaves.totalDays,
-        payslip.sickLeaves.totalDays,
-        payslip.exceptionalLeaves.totalDays,
+        formatFrNumber(payslip.paidLeaves.totalDays),
+        formatFrNumber(payslip.unpaidLeaves.totalDays),
+        formatFrNumber(payslip.sickLeaves.totalDays),
+        formatFrNumber(payslip.exceptionalLeaves.totalDays),
         ''
       ];
 

--- a/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
+++ b/server/src/Infrastructure/HumanResource/Payslip/Action/GetUsersElementsCsvAction.ts
@@ -8,9 +8,6 @@ import { Response } from 'express';
 import { format } from 'date-fns';
 import { LeaveRequestSlotView } from 'src/Application/HumanResource/Leave/View/LeaveRequestSlotView';
 
-const formatFrNumber = (n: number) =>
-  n.toLocaleString('fr-FR').replaceAll(' ', '');
-
 @Controller('payslips.csv')
 @ApiCookieAuth()
 @UseGuards(AuthGuard('bearer'))
@@ -19,6 +16,10 @@ export class GetUsersElementsCsvAction {
     @Inject('IQueryBus')
     private readonly queryBus: IQueryBus
   ) {}
+
+  private formatNumber(value: number): string {
+    return value.toLocaleString('fr-FR').replace(/\s/g, '');
+  }
 
   @Get()
   public async index(@Res() res: Response) {
@@ -65,17 +66,17 @@ export class GetUsersElementsCsvAction {
         payslip.firstName,
         payslip.contract,
         payslip.joiningDate,
-        formatFrNumber(payslip.annualEarnings),
-        formatFrNumber(Math.round(payslip.monthlyEarnings * 100) / 100),
+        this.formatNumber(payslip.annualEarnings),
+        this.formatNumber(Math.round(payslip.monthlyEarnings * 100) / 100),
         payslip.workingTime === 'full_time' ? 'Temps plein' : 'Temps partiel',
-        formatFrNumber(payslip.transportFee),
-        formatFrNumber(payslip.sustainableMobilityFee),
+        this.formatNumber(payslip.transportFee),
+        this.formatNumber(payslip.sustainableMobilityFee),
         payslip.mealTickets,
         payslip.healthInsurance === 'yes' ? 'Oui' : 'Non',
-        formatFrNumber(payslip.paidLeaves.totalDays),
-        formatFrNumber(payslip.unpaidLeaves.totalDays),
-        formatFrNumber(payslip.sickLeaves.totalDays),
-        formatFrNumber(payslip.exceptionalLeaves.totalDays),
+        this.formatNumber(payslip.paidLeaves.totalDays),
+        this.formatNumber(payslip.unpaidLeaves.totalDays),
+        this.formatNumber(payslip.sickLeaves.totalDays),
+        this.formatNumber(payslip.exceptionalLeaves.totalDays),
         ''
       ];
 


### PR DESCRIPTION
Cette PR 

* Met la colonne NOM en premier (les données sont triées par nom alphabétique croissant)
* Corrige le format des nombres dans le CSV des éléments de paie


Exemple:

* Avant : 84.100000001
* Après 84,1

Je faisais la conversion à la main jusqu'ici pour envoyer qqc de propre, c'est mieux de corriger Permacoop