### PR TITLE
Document CI deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - master
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   build:

--- a/prod/README.md
+++ b/prod/README.md
@@ -172,6 +172,17 @@ If an environment is not used anymore, it should be decommissioned to remove unu
   * Drop the environment from the environment list in this file.
 * Drop the [computing resources](#computing-resources) allocated to the environment.
 
+## CI deployment
+
+The `master` branch is deployed using the GitHub Actions `deploy.yml` workflow.
+
+This requires configuring a deployment SSH key:
+
+* Connect to the production VM
+* Run `$ ssh-keygen -t ed25519 -C "equipe@fairness.coop" -f ~/.ssh/github_actions`
+* Store the output of `cat ~/.ssh/github_actions` as `SSH_PRIVATE_KEY` in the [GitHub Actions secrets](https://github.com/fairnesscoop/permacoop/settings/secrets/actions)
+* Run `$ ssh-keyscan -H -t ed25519 permacoop.fairness.coop`, then store this as `SSH_KNOWN_HOSTS` in the GitHub Actions secrets.
+
 ## Tools
 
 ### Testing on a Vagrant VM


### PR DESCRIPTION
Dans #286 on n'avait pas documenté comment configurer le déploiement SSH Ansible lancé sur GitHub Actions

J'ai eu besoin de regénérer les clés SSH (tentative suite à expiration des clés publiques de Github), et donc de refaire la config

Voilà donc une PR qui

* ajoute la doc correspondante
* Ajoute aussi `workflow_dispatch` pour pouvoir déclencher un déploiement manuellement
