### PR TITLE
Fix: make default ProjectDTO.page null

### DIFF
--- a/server/src/Infrastructure/Project/DTO/FiltersDTO.spec.ts
+++ b/server/src/Infrastructure/Project/DTO/FiltersDTO.spec.ts
@@ -3,11 +3,16 @@ import { validate } from 'class-validator';
 
 describe('FiltersDTO', () => {
   it('testValidDTO', async () => {
-    const dto = new FiltersDTO();
+    let dto = new FiltersDTO();
+    expect(dto.page).toBeNull();
+    dto.customerId = '2218609f-293b-4438-b3a0-cce8961e8acc';
+    let validation = await validate(dto);
+    expect(validation).toHaveLength(0);
+
+    dto = new FiltersDTO();
     dto.customerId = '2218609f-293b-4438-b3a0-cce8961e8acc';
     dto.page = 1;
-
-    const validation = await validate(dto);
+    validation = await validate(dto);
     expect(validation).toHaveLength(0);
   });
 

--- a/server/src/Infrastructure/Project/DTO/FiltersDTO.ts
+++ b/server/src/Infrastructure/Project/DTO/FiltersDTO.ts
@@ -8,7 +8,7 @@ export class FiltersDTO {
   @Min(1)
   @Max(10000)
   @Type(() => Number)
-  public page?: number = 1;
+  public page?: number = null;
 
   @ApiPropertyOptional()
   @IsOptional()


### PR DESCRIPTION
* Correctif pour #412 

WAHIS (le 31e projet) ne s'affichait toujours pas

En fait, il fallait que la valeur par défaut de `page` dans le DTO passe aussi à null... Sinon pour l'instant le select requête toujours l'équivalent de `/projects?page=1`