### PR TITLE
Add sports pass fee

### DIFF
--- a/migrations/1710429580134-add_sports_pass_fee_to_user_administrative.ts
+++ b/migrations/1710429580134-add_sports_pass_fee_to_user_administrative.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class addSportsPassFeeToUserAdministrative1710429580134 implements MigrationInterface {
+    name = 'addSportsPassFeeToUserAdministrative1710429580134'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_administrative" ADD "sportsPassFee" integer DEFAULT '0'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_administrative" DROP COLUMN "sportsPassFee"`);
+    }
+}

--- a/src/Application/HumanResource/Payslip/Query/GetUserElementsQueryHandler.spec.ts
+++ b/src/Application/HumanResource/Payslip/Query/GetUserElementsQueryHandler.spec.ts
@@ -57,6 +57,7 @@ describe('GetUserElementsQueryHandler', () => {
     const earnings = 2000000;
     const rawTransportFee = 7500;
     const rawSustainableMobilityFee = 7000;
+    const rawSportsPassFee = 3000;
     const userAdministrative = mock(UserAdministrative);
     when(userAdministrative.getContract()).thenReturn(ContractType.CDI);
     when(userAdministrative.isExecutivePosition()).thenReturn(true);
@@ -70,6 +71,7 @@ describe('GetUserElementsQueryHandler', () => {
     when(userAdministrative.getSustainableMobilityFee()).thenReturn(
       rawSustainableMobilityFee
     );
+    when(userAdministrative.getSportsPassFee()).thenReturn(rawSportsPassFee);
     when(userAdministrative.haveHealthInsurance()).thenReturn(true);
 
     when(user.getId()).thenReturn('3b8a1954-2ade-44a2-a03c-338985c327ef');
@@ -155,6 +157,7 @@ describe('GetUserElementsQueryHandler', () => {
     const yearlyEarning = earnings * 0.01;
     const transportFee = rawTransportFee * 0.01;
     const sustainableMobilityFee = rawSustainableMobilityFee * 0.01;
+    const sportsPassFee = rawSportsPassFee * 0.01;
 
     expect(await queryHandler.execute(query)).toMatchObject([
       new UserElementsView(
@@ -168,6 +171,7 @@ describe('GetUserElementsQueryHandler', () => {
         WorkingTimeType.FULL_TIME,
         transportFee,
         sustainableMobilityFee,
+        sportsPassFee,
         5,
         true,
         new UserLeavesView(0, [

--- a/src/Application/HumanResource/Payslip/Query/GetUsersElementsQueryHandler.ts
+++ b/src/Application/HumanResource/Payslip/Query/GetUsersElementsQueryHandler.ts
@@ -59,6 +59,7 @@ export class GetUsersElementsQueryHandler {
           user.getUserAdministrative().getWorkingTime(),
           user.getUserAdministrative().getTransportFee() * 0.01,
           user.getUserAdministrative().getSustainableMobilityFee() * 0.01,
+          user.getUserAdministrative().getSportsPassFee() * 0.01,
           mealTicketsByUser[user.getId()],
           user.getUserAdministrative().haveHealthInsurance(),
           this.createUserLeavesView(userLeaves.paid, date),

--- a/src/Application/HumanResource/Payslip/View/UserElementsView.ts
+++ b/src/Application/HumanResource/Payslip/View/UserElementsView.ts
@@ -12,6 +12,7 @@ export class UserElementsView {
     public readonly workingTime: string,
     public readonly transportFee: number,
     public readonly sustainableMobilityFee: number,
+    public readonly sportsPassFee: number,
     public readonly mealTickets: number,
     public readonly healthInsurance: boolean,
     public readonly paidLeaves: UserLeavesView,

--- a/src/Application/HumanResource/User/Command/CreateUserCommand.ts
+++ b/src/Application/HumanResource/User/Command/CreateUserCommand.ts
@@ -15,6 +15,7 @@ export interface IUserAdministrativeCommand {
   leavingDate: string;
   transportFee: number;
   sustainableMobilityFee: number;
+  sportsPassFee: number;
 }
 
 export class CreateUserCommand implements ICommand {

--- a/src/Application/HumanResource/User/Command/CreateUserCommandHandler.spec.ts
+++ b/src/Application/HumanResource/User/Command/CreateUserCommandHandler.spec.ts
@@ -35,7 +35,8 @@ describe('CreatUserCommandHandler', () => {
     joiningDate: '2018-04-09',
     leavingDate: null,
     transportFee: 75.2,
-    sustainableMobilityFee: 70
+    sustainableMobilityFee: 70,
+    sportsPassFee: 30
   };
   const userAdministrative = new UserAdministrative(
     5000000,
@@ -46,7 +47,8 @@ describe('CreatUserCommandHandler', () => {
     '2018-04-09',
     null,
     7520,
-    7000
+    7000,
+    3000
   );
 
   let userRepository: UserRepository;

--- a/src/Application/HumanResource/User/Command/CreateUserCommandHandler.ts
+++ b/src/Application/HumanResource/User/Command/CreateUserCommandHandler.ts
@@ -76,7 +76,8 @@ export class CreateUserCommandHandler {
       joiningDate,
       leavingDate,
       transportFee,
-      sustainableMobilityFee
+      sustainableMobilityFee,
+      sportsPassFee
     } = userAdministrative;
 
     return await this.userAdministrativeRepository.save(
@@ -89,7 +90,8 @@ export class CreateUserCommandHandler {
         joiningDate,
         leavingDate ? leavingDate : null,
         transportFee ? Math.round(transportFee * 100) : 0,
-        sustainableMobilityFee ? Math.round(sustainableMobilityFee * 100) : 0
+        sustainableMobilityFee ? Math.round(sustainableMobilityFee * 100) : 0,
+        sportsPassFee ? Math.round(sportsPassFee * 100) : 0
       )
     );
   }

--- a/src/Application/HumanResource/User/Command/UpdateUserCommand.ts
+++ b/src/Application/HumanResource/User/Command/UpdateUserCommand.ts
@@ -17,6 +17,7 @@ export class UpdateUserCommand implements ICommand {
     public readonly joiningDate: string,
     public readonly leavingDate: string,
     public readonly transportFee: number,
-    public readonly sustainableMobilityFee: number
+    public readonly sustainableMobilityFee: number,
+    public readonly sportsPassFee: number
   ) {}
 }

--- a/src/Application/HumanResource/User/Command/UpdateUserCommandHandler.spec.ts
+++ b/src/Application/HumanResource/User/Command/UpdateUserCommandHandler.spec.ts
@@ -31,7 +31,8 @@ describe('UpdateProfileCommandHandler', () => {
     '2018-01-01',
     null,
     75.2,
-    70
+    70,
+    30
   );
 
   beforeEach(() => {
@@ -74,7 +75,8 @@ describe('UpdateProfileCommandHandler', () => {
       '2017-08-01',
       '2018-12-31',
       null,
-      7000
+      7000,
+      3000
     );
     const user = new User(
       'John',
@@ -105,7 +107,8 @@ describe('UpdateProfileCommandHandler', () => {
       '2018-01-01',
       null,
       7520,
-      7000
+      7000,
+      3000
     );
     verify(
       userRepository.save(
@@ -137,7 +140,8 @@ describe('UpdateProfileCommandHandler', () => {
       '2017-08-01',
       '2018-12-31',
       null,
-      7000
+      7000,
+      3000
     );
     const user = new User(
       'John',

--- a/src/Application/HumanResource/User/Command/UpdateUserCommandHandler.ts
+++ b/src/Application/HumanResource/User/Command/UpdateUserCommandHandler.ts
@@ -27,7 +27,8 @@ export class UpdateUserCommandHandler {
       joiningDate,
       leavingDate,
       transportFee,
-      sustainableMobilityFee
+      sustainableMobilityFee,
+      sportsPassFee
     } = command;
 
     const user = await this.userRepository.findOneById(id);
@@ -53,7 +54,8 @@ export class UpdateUserCommandHandler {
       joiningDate,
       leavingDate ? leavingDate : null,
       transportFee ? Math.round(transportFee * 100) : 0,
-      sustainableMobilityFee ? Math.round(sustainableMobilityFee * 100) : 0
+      sustainableMobilityFee ? Math.round(sustainableMobilityFee * 100) : 0,
+      sportsPassFee ? Math.round(sportsPassFee * 100) : 0
     );
 
     await this.userRepository.save(user);

--- a/src/Application/HumanResource/User/Query/GetUserAdministrativeByIdQueryHandler.ts
+++ b/src/Application/HumanResource/User/Query/GetUserAdministrativeByIdQueryHandler.ts
@@ -37,7 +37,8 @@ export class GetUserAdministrativeByIdQueryHandler {
         userAdministrative.getJoiningDate(),
         userAdministrative.getLeavingDate(),
         userAdministrative.getTransportFee() * 0.01,
-        userAdministrative.getSustainableMobilityFee() * 0.01
+        userAdministrative.getSustainableMobilityFee() * 0.01,
+        userAdministrative.getSportsPassFee() * 0.01
       );
     }
 

--- a/src/Application/HumanResource/User/View/UserAdministrativeView.ts
+++ b/src/Application/HumanResource/User/View/UserAdministrativeView.ts
@@ -13,6 +13,7 @@ export class UserAdministrativeView {
     public readonly joiningDate: string,
     public readonly leavingDate: string,
     public readonly transportFee: number,
-    public readonly sustainableMobilityFee: number
+    public readonly sustainableMobilityFee: number,
+    public readonly sportsPassFee: number
   ) {}
 }

--- a/src/Domain/HumanResource/User/UserAdministrative.entity.spec.ts
+++ b/src/Domain/HumanResource/User/UserAdministrative.entity.spec.ts
@@ -15,7 +15,8 @@ describe('UserAdministrative.entity', () => {
       '2020-01-01',
       '2021-01-01',
       7550,
-      7000
+      7000,
+      3000
     );
 
     expect(admin.getId()).toBe(undefined);
@@ -28,6 +29,7 @@ describe('UserAdministrative.entity', () => {
     expect(admin.isExecutivePosition()).toBe(true);
     expect(admin.haveHealthInsurance()).toBe(true);
     expect(admin.getSustainableMobilityFee()).toBe(7000);
+    expect(admin.getSportsPassFee()).toBe(3000);
   });
 
   it('testUpdate', () => {
@@ -40,7 +42,8 @@ describe('UserAdministrative.entity', () => {
       '2020-01-01',
       null,
       7550,
-      7000
+      7000,
+      3000
     );
 
     admin.update(
@@ -52,7 +55,8 @@ describe('UserAdministrative.entity', () => {
       '2020-01-02',
       '2021-01-02',
       null,
-      3000
+      3000,
+      2000
     );
     expect(admin.getAnnualEarnings()).toBe(3000000);
     expect(admin.getContract()).toBe(ContractType.APPRENTICESHIP);
@@ -63,5 +67,6 @@ describe('UserAdministrative.entity', () => {
     expect(admin.getLeavingDate()).toBe('2021-01-02');
     expect(admin.getTransportFee()).toBe(null);
     expect(admin.getSustainableMobilityFee()).toBe(3000);
+    expect(admin.getSportsPassFee()).toBe(2000);
   });
 });

--- a/src/Domain/HumanResource/User/UserAdministrative.entity.ts
+++ b/src/Domain/HumanResource/User/UserAdministrative.entity.ts
@@ -34,6 +34,9 @@ export class UserAdministrative {
   @Column({ type: 'integer', default: 0, nullable: true })
   private sustainableMobilityFee: number;
 
+  @Column({ type: 'integer', default: 0, nullable: true })
+  private sportsPassFee: number;
+
   @Column({ type: 'boolean', nullable: false })
   private healthInsurance: boolean;
 
@@ -61,7 +64,8 @@ export class UserAdministrative {
     joiningDate: string,
     leavingDate?: string,
     transportFee?: number,
-    sustainableMobilityFee?: number
+    sustainableMobilityFee?: number,
+    sportsPassFee?: number
   ) {
     this.annualEarnings = annualEarnings;
     this.healthInsurance = healthInsurance;
@@ -72,6 +76,7 @@ export class UserAdministrative {
     this.leavingDate = leavingDate;
     this.transportFee = transportFee;
     this.sustainableMobilityFee = sustainableMobilityFee;
+    this.sportsPassFee = sportsPassFee;
   }
 
   public getId(): string {
@@ -96,6 +101,10 @@ export class UserAdministrative {
 
   public getSustainableMobilityFee(): number {
     return this.sustainableMobilityFee;
+  }
+
+  public getSportsPassFee(): number {
+    return this.sportsPassFee;
   }
 
   public haveHealthInsurance(): boolean {
@@ -123,7 +132,8 @@ export class UserAdministrative {
     joiningDate: string,
     leavingDate: string | null,
     transportFee: number,
-    sustainableMobilityFee: number
+    sustainableMobilityFee: number,
+    sportsPassFee: number
   ): void {
     this.annualEarnings = annualEarnings;
     this.contract = contract;
@@ -134,5 +144,6 @@ export class UserAdministrative {
     this.leavingDate = leavingDate;
     this.transportFee = transportFee;
     this.sustainableMobilityFee = sustainableMobilityFee;
+    this.sportsPassFee = sportsPassFee;
   }
 }

--- a/src/Infrastructure/HumanResource/PayrollElements/Table/PayrollElementsTableFactory.ts
+++ b/src/Infrastructure/HumanResource/PayrollElements/Table/PayrollElementsTableFactory.ts
@@ -18,6 +18,7 @@ export class PayrollElementsTableFactory {
       'payroll-elements-workingTime',
       'payroll-elements-transportFee',
       'payroll-elements-sustainableMobilityFee',
+      'payroll-elements-sportsPassFee',
       'payroll-elements-mealTickets',
       'payroll-elements-healthInsurance',
       'payroll-elements-paidLeaves',
@@ -47,6 +48,9 @@ export class PayrollElementsTableFactory {
         .trans('common-money', { value: item.transportFee })
         .trans('common-money', {
           value: item.sustainableMobilityFee
+        })
+        .trans('common-money', {
+          value: item.sportsPassFee
         })
         .value(item.mealTickets)
         .trans(item.healthInsurance ? 'common-yes' : 'common-no')

--- a/src/Infrastructure/HumanResource/User/Controller/EditUserController.ts
+++ b/src/Infrastructure/HumanResource/User/Controller/EditUserController.ts
@@ -18,7 +18,6 @@ import { IdDTO } from 'src/Infrastructure/Common/DTO/IdDTO';
 import { UserAdministrativeDTO } from '../DTO/UserAdministrativeDTO';
 import { IsAuthenticatedGuard } from '../Security/IsAuthenticatedGuard';
 import { WithName } from 'src/Infrastructure/Common/ExtendedRouting/WithName';
-import { GetUserByIdQuery } from 'src/Application/HumanResource/User/Query/GetUserByIdQuery';
 import { RouteNameResolver } from 'src/Infrastructure/Common/ExtendedRouting/RouteNameResolver';
 import { UserRole } from 'src/Domain/HumanResource/User/User.entity';
 import {
@@ -68,7 +67,8 @@ export class EditUserController {
       joiningDate,
       leavingDate,
       transportFee,
-      sustainableMobilityFee
+      sustainableMobilityFee,
+      sportsPassFee
     } = userAdministrativeDto;
 
     try {
@@ -84,7 +84,8 @@ export class EditUserController {
           joiningDate,
           leavingDate ? leavingDate : null,
           transportFee,
-          sustainableMobilityFee
+          sustainableMobilityFee,
+          sportsPassFee
         )
       );
 

--- a/src/Infrastructure/HumanResource/User/DTO/UserAdministrativeDTO.spec.ts
+++ b/src/Infrastructure/HumanResource/User/DTO/UserAdministrativeDTO.spec.ts
@@ -16,6 +16,7 @@ describe('UserAdministrativeDTO', () => {
     dto.executivePosition = true;
     dto.healthInsurance = true;
     dto.transportFee = 75.2;
+    dto.sportsPassFee = 30;
     dto.joiningDate = '2020-12-17T03:24:00';
     dto.leavingDate = '2021-12-17T03:24:00';
 

--- a/src/Infrastructure/HumanResource/User/DTO/UserAdministrativeDTO.ts
+++ b/src/Infrastructure/HumanResource/User/DTO/UserAdministrativeDTO.ts
@@ -37,6 +37,11 @@ export class UserAdministrativeDTO {
   @Min(0)
   public sustainableMobilityFee: number;
 
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  public sportsPassFee: number;
+
   @IsNotEmpty()
   @Transform((_, { healthInsurance }) => healthInsurance === 'true')
   @IsBoolean()

--- a/src/Infrastructure/HumanResource/User/Repository/UserAdministrativeRepository.ts
+++ b/src/Infrastructure/HumanResource/User/Repository/UserAdministrativeRepository.ts
@@ -27,7 +27,8 @@ export class UserAdministrativeRepository
         'userAdministrative.executivePosition',
         'userAdministrative.contract',
         'userAdministrative.workingTime',
-        'userAdministrative.sustainableMobilityFee'
+        'userAdministrative.sustainableMobilityFee',
+        'userAdministrative.sportsPassFee'
       ])
       .innerJoin('userAdministrative.user', 'user')
       .where('user.id = :userId', { userId })

--- a/src/Infrastructure/HumanResource/User/Repository/UserRepository.ts
+++ b/src/Infrastructure/HumanResource/User/Repository/UserRepository.ts
@@ -97,7 +97,8 @@ export class UserRepository implements IUserRepository {
         'userAdministrative.executivePosition',
         'userAdministrative.contract',
         'userAdministrative.workingTime',
-        'userAdministrative.sustainableMobilityFee'
+        'userAdministrative.sustainableMobilityFee',
+        'userAdministrative.sportsPassFee'
       ]);
     query.innerJoin('user.userAdministrative', 'userAdministrative');
     query.andWhere('user.role <> :role', { role: UserRole.ACCOUNTANT });

--- a/src/templates/pages/users/_form.njk
+++ b/src/templates/pages/users/_form.njk
@@ -39,20 +39,25 @@
         </div>
     </div>
 
-    <div class="pc-grid pc-gap" style="--grid-cols: 3">
+    <div class="pc-grid pc-gap" style="--grid-cols: 4">
         <div class="pc-input-group">
             <label class="pc-label required" for="annualEarnings">{{ 'users-annualEarnings'|trans }}</label>
             <input type="number" min="0" id="annualEarnings" name="annualEarnings" required value="{% if userAdministrative %}{{ userAdministrative.annualEarnings }}{% else %}0{% endif %}">
         </div>
-    
+
         <div class="pc-input-group">
             <label class="pc-label required" for="transportFee">{{ 'users-transportFee'|trans }}</label>
             <input type="number" min="0" step="any" id="transportFee" name="transportFee" required value="{% if userAdministrative %}{{ userAdministrative.transportFee }}{% else %}0{% endif %}">
         </div>
-    
+
         <div class="pc-input-group">
             <label class="pc-label required" for="sustainableMobilityFee">{{ 'users-sustainableMobilityFee'|trans }}</label>
             <input type="number" min="0" step="any" id="sustainableMobilityFee" name="sustainableMobilityFee" required value="{% if userAdministrative %}{{ userAdministrative.sustainableMobilityFee }}{% else %}0{% endif %}">
+        </div>
+
+        <div class="pc-input-group">
+            <label class="pc-label required" for="sportsPassFee">{{ 'users-sportsPassFee'|trans }}</label>
+            <input type="number" min="0" step="any" id="sportsPassFee" name="sportsPassFee" required value="{% if userAdministrative %}{{ userAdministrative.sportsPassFee }}{% else %}0{% endif %}">
         </div>
     </div>
 
@@ -61,7 +66,7 @@
             <label class="pc-label required" for="joiningDate">{{ 'users-joiningDate'|trans }}</label>
             <input type="date" id="joiningDate" name="joiningDate" required {% if userAdministrative %}value="{{ userAdministrative.joiningDate }}"{% endif %}>
         </div>
-    
+
         <div class="pc-input-group">
             <label class="pc-label" for="leavingDate">{{ 'users-leavingDate'|trans }}</label>
             <input type="date" id="leavingDate" name="leavingDate" {% if userAdministrative %}value="{{ userAdministrative.leavingDate }}"{% endif %}>

--- a/src/translations/fr-FR.ftl
+++ b/src/translations/fr-FR.ftl
@@ -214,6 +214,7 @@ payroll-elements-workingTime = TC / TP
 payroll-elements-executive = Cadre
 payroll-elements-transportFee = Transport
 payroll-elements-sustainableMobilityFee = Mobilité durable
+payroll-elements-sportsPassFee = Abonnement sportif
 payroll-elements-mealTickets = Tickets resto
 payroll-elements-healthInsurance = Mutuelle
 payroll-elements-paidLeaves = Congés payés
@@ -269,6 +270,7 @@ users-healthInsurance = Mutuelle
 users-annualEarnings = Salaire annuel brut
 users-transportFee = Frais de transport
 users-sustainableMobilityFee = Forfait mobilité durable
+users-sportsPassFee = Abonnement sportif
 users-joiningDate = Date d'entrée
 users-leavingDate = Date de sortie
 


### PR DESCRIPTION
Dans le cadre du projet abonnement sportif (voir le détail ici : https://wiki.fairness.coop/fr/references/decisions/indeminit%C3%A9-sport) cette PR permet de rajouter un champ `sportsPassFee` dans les informations administratives de l'utilisateur. 
Ce champ se retrouvera exporté dans les éléments de paies.

:eyes: 

![image](https://github.com/fairnesscoop/permacoop/assets/2683379/faf53a04-aea4-4be8-b99c-9d7ec2e5678f)
![image](https://github.com/fairnesscoop/permacoop/assets/2683379/57c644c2-322c-4082-a085-9de7e174cb65)
