### PR TITLE
FairCalendar: corrige l'affichage de la liste d'events en mode no-JS

### DIFF
--- a/src/templates/pages/faircalendar/_event_list.njk
+++ b/src/templates/pages/faircalendar/_event_list.njk
@@ -24,7 +24,7 @@
             </div>
         </fieldset>
 
-        <div id="list-view" class="pc-table-wrapper" {% if viewName != 'list' %}hidden{% endif %}>
+        <div id="list-view" class="pc-table-wrapper">
             <table class="pc-table" style="--table-padding: var(--v); --table-desktop-padding: var(--v) var(--w)">
                 <colgroup>
                     <col>


### PR DESCRIPTION
Comportement attendu : quand JS est désactivé, la vue "liste" de FairCalendar s'affiche dans tous les cas

Comportement réel : quand on est sur la vue "calendrier" et qu'on désactive JS, la vue "liste" ne s'affichait pas car l'attribut `hidden` n'était pas retiré par le JS. Dans le HTML de base il faut donc que cet attribut ne soit pas présent.