### PR TITLE
Comment a leave request when it contains a postponed worked free day

### DIFF
--- a/src/Application/HumanResource/Leave/Command/CreateLeaveRequestCommandHandler.spec.ts
+++ b/src/Application/HumanResource/Leave/Command/CreateLeaveRequestCommandHandler.spec.ts
@@ -11,11 +11,13 @@ import { LeaveRequestAlreadyExistForThisPeriodException } from 'src/Domain/Human
 import { DoesLeaveExistForPeriod } from 'src/Domain/FairCalendar/Specification/DoesLeaveExistForPeriod';
 import { EventsOrLeavesAlreadyExistForThisPeriodException } from 'src/Domain/FairCalendar/Exception/EventsOrLeavesAlreadyExistForThisPeriodException';
 import { LeaveRequestRepository } from 'src/Infrastructure/HumanResource/Leave/Repository/LeaveRequestRepository';
+import { DoesLeaveRequestLackPostponedWorkedFreeDays } from 'src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays';
 
 describe('CreateLeaveRequestCommandHandler', () => {
   let leaveRequestRepository: LeaveRequestRepository;
   let doesLeaveRequestExistForPeriod: DoesLeaveRequestExistForPeriod;
   let doesLeaveExistForPeriod: DoesLeaveExistForPeriod;
+  let doesLeaveRequestLackPostponedWorkedFreeDays: DoesLeaveRequestLackPostponedWorkedFreeDays;
   let handler: CreateLeaveRequestCommandHandler;
 
   const user = mock(User);
@@ -33,11 +35,15 @@ describe('CreateLeaveRequestCommandHandler', () => {
     leaveRequestRepository = mock(LeaveRequestRepository);
     doesLeaveRequestExistForPeriod = mock(DoesLeaveRequestExistForPeriod);
     doesLeaveExistForPeriod = mock(DoesLeaveExistForPeriod);
+    doesLeaveRequestLackPostponedWorkedFreeDays = mock(
+      DoesLeaveRequestLackPostponedWorkedFreeDays
+    );
 
     handler = new CreateLeaveRequestCommandHandler(
       instance(leaveRequestRepository),
       instance(doesLeaveRequestExistForPeriod),
-      instance(doesLeaveExistForPeriod)
+      instance(doesLeaveExistForPeriod),
+      instance(doesLeaveRequestLackPostponedWorkedFreeDays)
     );
   });
 
@@ -69,6 +75,12 @@ describe('CreateLeaveRequestCommandHandler', () => {
           instance(user),
           '2019-01-04',
           '2019-01-06'
+        )
+      ).never();
+      verify(
+        doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+          anything(),
+          anything()
         )
       ).never();
       verify(leaveRequestRepository.save(anything())).never();
@@ -114,6 +126,12 @@ describe('CreateLeaveRequestCommandHandler', () => {
           '2019-01-06'
         )
       ).once();
+      verify(
+        doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+          anything(),
+          anything()
+        )
+      ).never();
       verify(leaveRequestRepository.save(anything())).never();
     }
   });
@@ -138,6 +156,12 @@ describe('CreateLeaveRequestCommandHandler', () => {
         '2019-01-06'
       )
     ).thenResolve(false);
+    when(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).thenReturn(false);
 
     when(
       leaveRequestRepository.save(
@@ -174,6 +198,12 @@ describe('CreateLeaveRequestCommandHandler', () => {
       )
     ).once();
     verify(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).once();
+    verify(
       leaveRequestRepository.save(
         deepEqual(
           new LeaveRequest(
@@ -184,6 +214,90 @@ describe('CreateLeaveRequestCommandHandler', () => {
             '2019-01-06',
             true,
             'H&M wedding'
+          )
+        )
+      )
+    ).once();
+  });
+
+  it('testLeaveRequestLackPostponedWorkedFreeDay', async () => {
+    const leaveRequest = mock(LeaveRequest);
+    when(leaveRequest.getId()).thenReturn(
+      'cfdd06eb-cd71-44b9-82c6-46110b30ce05'
+    );
+
+    when(
+      doesLeaveRequestExistForPeriod.isSatisfiedBy(
+        instance(user),
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).thenResolve(false);
+    when(
+      doesLeaveExistForPeriod.isSatisfiedBy(
+        instance(user),
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).thenResolve(false);
+    when(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).thenReturn(true);
+
+    when(
+      leaveRequestRepository.save(
+        deepEqual(
+          new LeaveRequest(
+            instance(user),
+            Type.PAID,
+            '2019-01-04',
+            true,
+            '2019-01-06',
+            true,
+            'H&M wedding ⚠️ Cette demande de congé contient un ou plusieurs jour(s) férié(s) glissant non pris en compte.'
+          )
+        )
+      )
+    ).thenResolve(instance(leaveRequest));
+
+    expect(await handler.execute(command)).toBe(
+      'cfdd06eb-cd71-44b9-82c6-46110b30ce05'
+    );
+
+    verify(
+      doesLeaveRequestExistForPeriod.isSatisfiedBy(
+        instance(user),
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).once();
+    verify(
+      doesLeaveExistForPeriod.isSatisfiedBy(
+        instance(user),
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).once();
+    verify(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2019-01-04',
+        '2019-01-06'
+      )
+    ).once();
+    verify(
+      leaveRequestRepository.save(
+        deepEqual(
+          new LeaveRequest(
+            instance(user),
+            Type.PAID,
+            '2019-01-04',
+            true,
+            '2019-01-06',
+            true,
+            'H&M wedding ⚠️ Cette demande de congé contient un ou plusieurs jour(s) férié(s) glissant non pris en compte.'
           )
         )
       )

--- a/src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays.spec.ts
+++ b/src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays.spec.ts
@@ -1,0 +1,28 @@
+import { mock } from 'ts-mockito';
+import { DoesLeaveRequestLackPostponedWorkedFreeDays } from './DoesLeaveRequestLackPostponedWorkedFreeDays';
+
+describe('DoesLeaveRequestLackPostponedWorkedFreeDays', () => {
+  let doesLeaveRequestLackPostponedWorkedFreeDays: DoesLeaveRequestLackPostponedWorkedFreeDays;
+
+  beforeEach(() => {
+    doesLeaveRequestLackPostponedWorkedFreeDays = new DoesLeaveRequestLackPostponedWorkedFreeDays();
+  });
+
+  it('testLeaveRequestLackPostponedWorkedFreeDays', () => {
+    expect(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2024-07-01',
+        '2024-07-31'
+      )
+    ).toBe(true);
+  });
+
+  it('testLeaveRequestDoesntLackPostponedWorkedFreeDays', () => {
+    expect(
+      doesLeaveRequestLackPostponedWorkedFreeDays.isSatisfiedBy(
+        '2024-08-01',
+        '2024-08-30'
+      )
+    ).toBe(false);
+  });
+});

--- a/src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays.ts
+++ b/src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays.ts
@@ -1,0 +1,15 @@
+import { DateUtilsAdapter } from 'src/Infrastructure/Adapter/DateUtilsAdapter';
+const dateUtils: DateUtilsAdapter = new DateUtilsAdapter();
+
+export class DoesLeaveRequestLackPostponedWorkedFreeDays {
+  public isSatisfiedBy(startDate: string, endDate: string): boolean {
+    const workedFreeDays = dateUtils.getWorkedFreeDaysDuringAPeriod(
+      new Date(startDate),
+      new Date(endDate)
+    );
+
+    return workedFreeDays.some(workedFreeDay =>
+      dateUtils.isWeekend(workedFreeDay)
+    );
+  }
+}

--- a/src/Infrastructure/Adapter/DateUtilsAdapter.spec.ts
+++ b/src/Infrastructure/Adapter/DateUtilsAdapter.spec.ts
@@ -2,15 +2,19 @@ import { MonthDate } from 'src/Application/Common/MonthDate';
 import { DateUtilsAdapter } from './DateUtilsAdapter';
 
 describe('DateUtilsAdapter', () => {
+  let dateUtils: DateUtilsAdapter;
+
+  beforeEach(() => {
+    dateUtils = new DateUtilsAdapter();
+  });
+
   it('testFormat', () => {
-    const dateUtils = new DateUtilsAdapter();
     expect(
       dateUtils.format(new Date('2019-12-23T11:49:58.706Z'), 'y-MM-dd')
     ).toBe('2019-12-23');
   });
 
   it('testGetDaysInMonth', () => {
-    const dateUtils = new DateUtilsAdapter();
     expect(dateUtils.getDaysInMonth(new Date('2019-12-23T11:49:58.706Z'))).toBe(
       31
     );
@@ -20,7 +24,6 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testIsWeekend', () => {
-    const dateUtils = new DateUtilsAdapter();
     expect(dateUtils.isWeekend(new Date('2019-12-21T11:49:58.706Z'))).toBe(
       true
     );
@@ -30,7 +33,6 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testIsAWorkingDay', () => {
-    const dateUtils = new DateUtilsAdapter();
     expect(dateUtils.isAWorkingDay(new Date('2020-05-01T11:49:58.706Z'))).toBe(
       false
     );
@@ -43,15 +45,12 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testAddDaysToDate', () => {
-    const dateUtils = new DateUtilsAdapter();
     expect(
       dateUtils.addDaysToDate(new Date('2019-12-21T11:49:58.706Z'), 5)
     ).toMatchObject(new Date('2019-12-26T11:49:58.706Z'));
   });
 
   it('testGetCurrentDate', () => {
-    const dateUtils = new DateUtilsAdapter();
-
     expect(dateUtils.getCurrentDate()).toBeInstanceOf(Date);
     expect(dateUtils.getCurrentDateToISOString()).toBeDefined();
   });
@@ -59,7 +58,6 @@ describe('DateUtilsAdapter', () => {
   it('testGetWorkedDaysDuringAPeriod', () => {
     const startDate = new Date('2020-12-24');
     const endDate = new Date('2021-01-04');
-    const dateUtils = new DateUtilsAdapter();
 
     expect(
       dateUtils.getWorkedDaysDuringAPeriod(startDate, endDate)
@@ -74,8 +72,6 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testGetWorkedFreeDays', () => {
-    const dateUtils = new DateUtilsAdapter();
-
     expect(dateUtils.getWorkedFreeDays(2020)).toMatchObject([
       new Date(`2020-01-01T00:00:00.000Z`),
       new Date(`2020-05-01T00:00:00.000Z`),
@@ -104,8 +100,6 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testGetEasterDate', () => {
-    const dateUtils = new DateUtilsAdapter();
-
     expect(dateUtils.getEasterDate(2020)).toMatchObject(
       new Date(`2020-04-12T00:00:00.000Z`)
     );
@@ -121,16 +115,12 @@ describe('DateUtilsAdapter', () => {
   });
 
   it('testGetLeaveDuration', () => {
-    const dateUtils = new DateUtilsAdapter();
-
     expect(
       dateUtils.getLeaveDuration('2020-05-05', false, '2020-05-15', false)
     ).toBe(7);
   });
 
   it('testGetMinimumLeaveDuration', () => {
-    const dateUtils = new DateUtilsAdapter();
-
     expect(
       dateUtils.getLeaveDuration('2020-05-05', false, '2020-05-05', false)
     ).toBe(0.5);
@@ -141,19 +131,16 @@ describe('DateUtilsAdapter', () => {
     [new Date('2020-01-01T00:00:01.000Z'), 2020],
     [new Date('2020-12-31T23:59:59.000Z'), 2020]
   ])('testGetYear when date = %s', (date, expectedYear) => {
-    const dateUtils = new DateUtilsAdapter();
     expect(dateUtils.getYear(date)).toBe(expectedYear);
   });
 
   it('testGetLastDayOfYear', () => {
-    const dateUtils = new DateUtilsAdapter();
     const now = new Date('2021-12-12');
     const result = dateUtils.getLastDayOfYear(now);
     expect(result).toStrictEqual(new Date('2021-12-31'));
   });
 
   it('getFirstDayOfYear', () => {
-    const dateUtils = new DateUtilsAdapter();
     const now = new Date('2021-12-12');
     const result = dateUtils.getFirstDayOfYear(now);
     expect(result).toStrictEqual(new Date('2021-01-01'));
@@ -164,8 +151,54 @@ describe('DateUtilsAdapter', () => {
     [new Date('2021-12-31T23:59:59.000Z'), new MonthDate(2021, 12)],
     [new Date('2022-01-01T00:00:01.000Z'), new MonthDate(2022, 1)]
   ])('getMonth when date = %s', (date, expectedResult) => {
-    const dateUtils = new DateUtilsAdapter();
     const result = dateUtils.getMonth(date);
     expect(result).toStrictEqual(expectedResult);
+  });
+
+  it('testGetWorkedFreeDaysDuringAPeriod', () => {
+    expect(
+      dateUtils.getWorkedFreeDaysDuringAPeriod(
+        new Date('2024-07-01'),
+        new Date('2024-07-31')
+      )
+    ).toMatchObject([new Date('2024-07-14')]);
+
+    expect(
+      dateUtils.getWorkedFreeDaysDuringAPeriod(
+        new Date('2024-07-01'),
+        new Date('2024-09-31')
+      )
+    ).toMatchObject([new Date('2024-07-14'), new Date('2024-08-15')]);
+
+    expect(
+      dateUtils.getWorkedFreeDaysDuringAPeriod(
+        new Date('2024-07-01'),
+        new Date('2024-12-31')
+      )
+    ).toMatchObject([
+      new Date('2024-07-14'),
+      new Date('2024-08-15'),
+      new Date('2024-11-01'),
+      new Date('2024-11-11'),
+      new Date('2024-12-25')
+    ]);
+
+    expect(
+      dateUtils.getWorkedFreeDaysDuringAPeriod(
+        new Date('2024-07-01'),
+        new Date('2025-05-31')
+      )
+    ).toMatchObject([
+      new Date('2024-07-14'),
+      new Date('2024-08-15'),
+      new Date('2024-11-01'),
+      new Date('2024-11-11'),
+      new Date('2024-12-25'),
+      new Date('2025-01-01'),
+      new Date('2025-05-01'),
+      new Date('2025-05-08'),
+      new Date('2025-04-21'),
+      new Date('2025-05-29')
+    ]);
   });
 });

--- a/src/Infrastructure/Adapter/DateUtilsAdapter.ts
+++ b/src/Infrastructure/Adapter/DateUtilsAdapter.ts
@@ -186,6 +186,20 @@ export class DateUtilsAdapter implements IDateUtils {
     return this.makeDate(year, n, p);
   }
 
+  public getWorkedFreeDaysDuringAPeriod(start: Date, end: Date): Date[] {
+    const workedFreeDays: Date[] = [];
+
+    for (let year = this.getYear(start); year <= this.getYear(end); year++) {
+      workedFreeDays.push(...this.getWorkedFreeDays(year));
+    }
+
+    return workedFreeDays.filter(
+      workedFreeDay =>
+        start.toISOString() < workedFreeDay.toISOString() &&
+        workedFreeDay.toISOString() < end.toISOString()
+    );
+  }
+
   public getLeaveDuration(
     startDate: string,
     isStartsAllDay: boolean,

--- a/src/Infrastructure/HumanResource/humanResource.module.ts
+++ b/src/Infrastructure/HumanResource/humanResource.module.ts
@@ -80,6 +80,7 @@ import { ListMealTicketsController } from './MealTicket/Controller/ListMealTicke
 import { MealTicketTableFactory } from './MealTicket/Table/MealTicketTableFactory';
 import { AddMealTicketRemovalController } from './MealTicket/Controller/AddMealTicketRemovalController';
 import { ExportLeavesCalendarController } from './Leave/Controller/ExportLeavesCalendarController';
+import { DoesLeaveRequestLackPostponedWorkedFreeDays } from 'src/Domain/HumanResource/Leave/Specification/DoesLeaveRequestLackPostponedWorkedFreeDays';
 
 @Module({
   imports: [
@@ -163,6 +164,7 @@ import { ExportLeavesCalendarController } from './Leave/Controller/ExportLeavesC
     GetUsersElementsQueryHandler,
     CreateLeaveRequestCommandHandler,
     DoesLeaveRequestExistForPeriod,
+    DoesLeaveRequestLackPostponedWorkedFreeDays,
     RefuseLeaveRequestCommandHandler,
     CanLeaveRequestBeModerated,
     AcceptLeaveRequestCommandHandler,


### PR DESCRIPTION
Cette PR rajoute un commentaire à une demande de congé lorsque celle-ci contient un jour férié glissant (aka un jour férié qui tombe un week end).
Cela permet au créateur de la demande ainsi qu'à la personne qui la valide d'être notifié d'un potentiel oubli.

![Capture d’écran 2024-05-17 à 17 54 17](https://github.com/fairnesscoop/permacoop/assets/4798095/515900ad-3317-466b-9c3b-2d56760fdf1e)

⚠️ Cette PR pourra être mergée si la mise en place des "jours fériés glissants" est adoptée.

