### PR TITLE
Corrige affichage explication congés restants

### DIFF
--- a/src/assets/styles/defaults.css
+++ b/src/assets/styles/defaults.css
@@ -36,20 +36,3 @@ fieldset {
 dialog {
   margin: auto;
 }
-
-:popover-open {
-  position: absolute;
-  inset: unset;
-  margin: var(--w);
-  white-space: wrap;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-default);
-  padding: var(--w);
-  font-weight: normal;
-  text-transform: none;
-}
-
-[popovertarget]:focus {
-  outline: solid 2px;
-}

--- a/src/assets/styles/utilities/placement.css
+++ b/src/assets/styles/utilities/placement.css
@@ -2,7 +2,3 @@
   display: grid;
   place-items: center;
 }
-
-.pc-relative {
-  position: relative;
-}

--- a/src/assets/styles/utilities/text.css
+++ b/src/assets/styles/utilities/text.css
@@ -5,3 +5,13 @@
 .pc-bold {
   font-weight: bold;
 }
+
+.pc-text--default {
+  font-size: var(--font-size-default);
+  font-weight: normal;
+  text-transform: none;
+}
+
+.pc-text--small {
+  font-size: var(--font-size-sm);
+}

--- a/src/templates/pages/leave_requests/overview/days_remaining_column_header.njk
+++ b/src/templates/pages/leave_requests/overview/days_remaining_column_header.njk
@@ -1,16 +1,5 @@
-<span>
-    {{ 'leaves-overview-daysRemaining'|trans }}
-</span>
-
-<span class="pc-relative">
-    <button
-        popovertarget="leaves-explanation"
-        class="pc-btn pc-btn--secondary pc-btn--circle"
-        title="{{ 'leaves-overview-daysRemaining-showExplanation'|trans }}"
-        aria-label="{{ 'leaves-overview-daysRemaining-showExplanation'|trans }}"
-    >i</button>
-
-    <div id="leaves-explanation" popover>
-        {{ 'leaves-overview-daysRemaining-explanation'|trans({ daysPerYear: daysPerYear }) }}
-    </div>
+{{ 'leaves-overview-daysRemaining'|trans }}
+<br>
+<span class="pc-text--default pc-text--small">
+    ({{ 'leaves-overview-daysRemaining-explanation'|trans({ daysPerYear: daysPerYear }) }})
 </span>

--- a/src/translations/fr-FR.ftl
+++ b/src/translations/fr-FR.ftl
@@ -193,11 +193,11 @@ leaves-overview-daysRemaining-value = {$daysRemaining ->
     [1] 1 jour
     *[other] {$daysRemaining} jours
 }
-leaves-overview-daysRemaining-explanation = Estimation sur une base de {$daysPerYear ->
+leaves-overview-daysRemaining-explanation = {$daysPerYear ->
     [0] 0
     [1] 1 jour
     *[other] {$daysPerYear} jours
-} par an, hors congés exceptionnels
+} par an, réinitialisé le 01/06, hors congés exceptionnels
 
 payroll-elements-title = Éléments de paie
 payroll-elements-page-title = Éléments de paie {DATETIME($date, month: "long", year: "numeric")}


### PR DESCRIPTION
* Suite à #442 

J'avais utilisé l'API Popover mais à cause de différences entre navigateurs, je simplifie et on affiche tout le temps l'explication

![Screenshot 2024-07-12 at 16-09-22 Congés - Permacoop](https://github.com/user-attachments/assets/fe84e6de-7e3a-48ad-bba3-06ff0d30ab03)
