### PR TITLE
Remet en place le lien d'abonnement au calendrier des congés

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
       - name: Tests
-        run: make ci
+        run: make ci BIN_DOCKER_COMPOSE="docker compose"
 
       - uses: codecov/codecov-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-compose = docker-compose -p permacoop
+BIN_DOCKER_COMPOSE=docker-compose
+
+compose = ${BIN_DOCKER_COMPOSE} -p permacoop
 
 run_server = ./tools/colorize_prefix.sh [server] 31
 run_watch = ./tools/colorize_prefix.sh [watch] 36

--- a/src/Infrastructure/HumanResource/Leave/Controller/ListLeaveRequestsController.ts
+++ b/src/Infrastructure/HumanResource/Leave/Controller/ListLeaveRequestsController.ts
@@ -54,11 +54,14 @@ export class ListLeaveRequestsController {
       userId
     );
 
+    const calendarToken = process.env.CALENDAR_TOKEN;
+
     return {
       table,
       overviewTable,
       pagination,
-      currentPage: dto.page
+      currentPage: dto.page,
+      calendarToken,
     };
   }
 }

--- a/src/Infrastructure/HumanResource/Leave/Controller/ListLeaveRequestsController.ts
+++ b/src/Infrastructure/HumanResource/Leave/Controller/ListLeaveRequestsController.ts
@@ -61,7 +61,7 @@ export class ListLeaveRequestsController {
       overviewTable,
       pagination,
       currentPage: dto.page,
-      calendarToken,
+      calendarToken
     };
   }
 }

--- a/src/templates/pages/leave_requests/list.njk
+++ b/src/templates/pages/leave_requests/list.njk
@@ -15,6 +15,16 @@
         {{ links.add(path('people_leave_requests_add'), text='leave-requests-add-title'|trans) }}
     </div>
 
+    <div class="pc-cluster pc-gap" style="--cluster-align: center">
+        <label for="calendarUrl">{{ 'leaves-calendar-url-title'|trans }}</label>
+        <input id="calendarUrl" class="pc-input" style="--input-width: fit-content" type="text" readonly value="{{ url('people_leaves_calendar') }}?token={{ calendarToken }}">
+        <pc-clipboard-button class="pc-js-only" data-source="#calendarUrl">
+            <button class="pc-btn pc-btn--muted" title="{{ 'clipboard-copy'|trans }}">
+                {{ icons.clipboard() }}
+            </button>
+        </pc-clipboard-button>
+    </div>
+
     <div class="pc-cluster" style="--cluster-gap: calc(3 * var(--w))">
         <div class="pc-stack">
             <h2>{{ 'leaves-summary-title'|trans }}</h2>


### PR DESCRIPTION
## Motivation

Je l'avais retiré par erreur dans #437 

Ce lien permet d'ajouter le calendrier au format iCal dans son application de calendrier (Thunderbird, Infomaniak Calendar, etc)

## Aperçu

![Screenshot 2024-09-27 at 15-33-10 Congés - Permacoop](https://github.com/user-attachments/assets/ba7be9bb-3cc0-484d-b7cf-8a63e8bbe6aa)
