### PR TITLE
Empêche de créer de nouveaux Congés maladie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/src/Domain/HumanResource/Leave/LeaveRequest.entity.ts
+++ b/src/Domain/HumanResource/Leave/LeaveRequest.entity.ts
@@ -17,6 +17,12 @@ export enum Type {
   RELOCATION = 'relocation'
 }
 
+export function getSelectableLeaveRequestTypes() {
+  const types = Object.values(Type);
+
+  return types.filter(t => t !== Type.MEDICAL);
+}
+
 export interface ILeaveRequestModeration {
   getStatus(): string;
   getUserId(): string;

--- a/src/Infrastructure/HumanResource/Leave/Controller/AddLeaveRequestController.ts
+++ b/src/Infrastructure/HumanResource/Leave/Controller/AddLeaveRequestController.ts
@@ -17,7 +17,7 @@ import { LoggedUser } from '../../User/Decorator/LoggedUser';
 import { IsAuthenticatedGuard } from '../../User/Security/IsAuthenticatedGuard';
 import { WithName } from 'src/Infrastructure/Common/ExtendedRouting/WithName';
 import { User } from 'src/Domain/HumanResource/User/User.entity';
-import { Type } from 'src/Domain/HumanResource/Leave/LeaveRequest.entity';
+import { getSelectableLeaveRequestTypes } from 'src/Domain/HumanResource/Leave/LeaveRequest.entity';
 import { RouteNameResolver } from 'src/Infrastructure/Common/ExtendedRouting/RouteNameResolver';
 
 @Controller('app/people/leave-requests/add')
@@ -33,10 +33,8 @@ export class AddLeaveRequestController {
   @WithName('people_leave_requests_add')
   @Render('pages/leave_requests/add.njk')
   public async get() {
-    const types = Object.values(Type);
-
     return {
-      types
+      types: getSelectableLeaveRequestTypes()
     };
   }
 

--- a/src/Infrastructure/HumanResource/Leave/Controller/EditLeaveRequestController.ts
+++ b/src/Infrastructure/HumanResource/Leave/Controller/EditLeaveRequestController.ts
@@ -18,6 +18,7 @@ import { IsAuthenticatedGuard } from '../../User/Security/IsAuthenticatedGuard';
 import { WithName } from 'src/Infrastructure/Common/ExtendedRouting/WithName';
 import { User } from 'src/Domain/HumanResource/User/User.entity';
 import {
+  getSelectableLeaveRequestTypes,
   Status,
   Type
 } from 'src/Domain/HumanResource/Leave/LeaveRequest.entity';
@@ -48,7 +49,7 @@ export class EditLeaveRequestController {
       new GetLeaveRequestByIdQuery(id, user)
     );
 
-    const types = Object.values(Type);
+    const types = getSelectableLeaveRequestTypes();
 
     return {
       leaveRequest,


### PR DESCRIPTION
Vu décision lors du Forum ouvert du 7 février 2025

Cette PR retire l'option "Congé maladie" de la liste déroulante lorsqu'on crée un nouveau congé

NB: les "congés maladie" existants ne sont pas supprimés et s'affichent toujours