### PR TITLE
Ne pas notifier Mattermost pour les congés menstruels

### DIFF
--- a/src/Application/HumanResource/Leave/Command/CreateLeaveRequestCommandHandler.ts
+++ b/src/Application/HumanResource/Leave/Command/CreateLeaveRequestCommandHandler.ts
@@ -106,6 +106,8 @@ export class CreateLeaveRequestCommandHandler {
       leaveRequest.autoAccept(this.dateUtils.getCurrentDateToISOString());
       await this.leaveRequestRepository.save(leaveRequest);
       this.eventBus.publish(new AcceptedLeaveRequestEvent(leaveRequest));
+
+      return leaveRequest.getId();
     }
 
     this.commandBus.execute(


### PR DESCRIPTION
Ajout d'une condition pour ne pas envoyer une notif sur Mattermost pour garder une logique d'anonymat et de discretion.